### PR TITLE
Fix CSteamUser constructor

### DIFF
--- a/classes/CSteamUser.js
+++ b/classes/CSteamUser.js
@@ -98,7 +98,7 @@ function CSteamUser(community, userData, customurl) {
 		});
 	}
 
-	function processItem(name, defaultVal) {
+	function processItem(userData, name, defaultVal) {
 		if(!userData[name]) {
 			return defaultVal;
 		}


### PR DESCRIPTION
The processItem function is missing its first argument, messing up all the CSteamUser's data.