### PR TITLE
Updates login code to use mobile login headers and cookies

### DIFF
--- a/components/webapi.js
+++ b/components/webapi.js
@@ -3,6 +3,10 @@ var SteamCommunity = require('../index.js');
 SteamCommunity.prototype.getWebApiOauthToken = function(callback) {
 	var self = this;
 
+	if( this.oAuthToken ) {
+		return callback( null, this.oAuthToken );
+	}
+
 	// Pull an oauth token from the webchat UI
 	this.request("https://steamcommunity.com/chat", function(err, response, body) {
 		if(self._checkHttpError(err, response, callback)) {

--- a/index.js
+++ b/index.js
@@ -78,7 +78,6 @@ SteamCommunity.prototype.login = function(details, callback) {
 			"captchagid": self._captchaGid,
 			"emailauth": details.authCode || "",
 			"emailsteamid": "",
-			"loginfriendlyname": "",
 			"password": hex2b64(key.encrypt(details.password)),
 			"remember_login": "true",
 			"rsatimestamp": json.timestamp,

--- a/index.js
+++ b/index.js
@@ -14,7 +14,17 @@ function SteamCommunity(localAddress) {
 	this._captchaGid = -1;
 	this.chatState = SteamCommunity.ChatState.Offline;
 
-	var defaults = {"jar": this._jar, "timeout": 50000};
+	var defaults = {
+		"jar": this._jar,
+		"timeout": 50000,
+		"headers": {
+			"X-Requested-With": "com.valvesoftware.android.steam.community",
+			"referer": "https://steamcommunity.com/mobilelogin?oauth_client_id=DE45CD61&oauth_scope=read_profile%20write_profile%20read_client%20write_client",
+			"user-agent": "Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; Google Nexus 4 - 4.1.1 - API 16 - 768x1280 Build/JRO03S) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30",
+			"accept": "text/javascript, text/html, application/xml, text/xml, */*"
+		}
+	};
+
 	if(localAddress) {
 		defaults.localAddress = localAddress;
 	}
@@ -26,6 +36,10 @@ function SteamCommunity(localAddress) {
 
 	// UTC
 	this._jar.setCookie(Request.cookie('timezoneOffset=0,0'), 'https://steamcommunity.com');
+
+	this._jar.setCookie(Request.cookie("mobileClientVersion=0 (2.1.3)"), "https://steamcommunity.com");
+	this._jar.setCookie(Request.cookie("mobileClient=android"), "https://steamcommunity.com");
+	this._jar.setCookie(Request.cookie("Steam_Language=english"), "https://steamcommunity.com");
 }
 
 SteamCommunity.prototype.login = function(details, callback) {
@@ -35,6 +49,7 @@ SteamCommunity.prototype.login = function(details, callback) {
 	}
 	
 	var self = this;
+	
 	this.request.post("https://steamcommunity.com/login/getrsakey/", {"form": {"username": details.accountName}}, function(err, response, body) {
 		if(err) {
 			callback(err);
@@ -62,7 +77,10 @@ SteamCommunity.prototype.login = function(details, callback) {
 			"remember_login": "true",
 			"rsatimestamp": json.timestamp,
 			"twofactorcode": details.twoFactorCode || "",
-			"username": details.accountName
+			"username": details.accountName,
+			"oauth_client_id": "DE45CD61",
+			"oauth_scope": "read_profile write_profile read_client write_client",
+			"loginfriendlyname": "#login_emailauth_friendlyname_mobile"
 		};
 		
 		self.request.post({
@@ -94,9 +112,12 @@ SteamCommunity.prototype.login = function(details, callback) {
 				callback(new Error(body.message || "Unknown error"));
 			} else {
 				var sessionID = generateSessionID();
+				var oAuth = JSON.parse( body.oauth );
 				self._jar.setCookie(Request.cookie('sessionid=' + sessionID), 'http://steamcommunity.com');
 				
-				self.steamID = new SteamID(body.transfer_parameters.steamid);
+				self.steamID = new SteamID(oAuth.steamid);
+				self.oAuthToken = oAuth.oauth_token;
+
 				var cookies = self._jar.getCookieString("https://steamcommunity.com").split(';').map(function(cookie) {
 					return cookie.trim();
 				});
@@ -249,6 +270,7 @@ SteamCommunity.prototype.getNotifications = function(callback) {
 };
 
 SteamCommunity.prototype.resetItemNotifications = function(callback) {
+	var self = this;
 	this.request.get("https://steamcommunity.com/my/inventory", function(err, response, body) {
 		if(!callback) {
 			return;

--- a/index.js
+++ b/index.js
@@ -16,13 +16,7 @@ function SteamCommunity(localAddress) {
 
 	var defaults = {
 		"jar": this._jar,
-		"timeout": 50000,
-		"headers": {
-			"X-Requested-With": "com.valvesoftware.android.steam.community",
-			"referer": "https://steamcommunity.com/mobilelogin?oauth_client_id=DE45CD61&oauth_scope=read_profile%20write_profile%20read_client%20write_client",
-			"user-agent": "Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; Google Nexus 4 - 4.1.1 - API 16 - 768x1280 Build/JRO03S) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30",
-			"accept": "text/javascript, text/html, application/xml, text/xml, */*"
-		}
+		"timeout": 50000
 	};
 
 	if(localAddress) {
@@ -48,8 +42,21 @@ SteamCommunity.prototype.login = function(details, callback) {
 	}
 	
 	var self = this;
+
+	// headers required to convince steam that we're logging in from a mobile device so that we can get the oAuth data
+	var mobileHeaders = {
+		"X-Requested-With": "com.valvesoftware.android.steam.community",
+		"referer": "https://steamcommunity.com/mobilelogin?oauth_client_id=DE45CD61&oauth_scope=read_profile%20write_profile%20read_client%20write_client",
+		"user-agent": "Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; Google Nexus 4 - 4.1.1 - API 16 - 768x1280 Build/JRO03S) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30",
+		"accept": "text/javascript, text/html, application/xml, text/xml, */*"
+	};
 	
-	this.request.post("https://steamcommunity.com/login/getrsakey/", {"form": {"username": details.accountName}}, function(err, response, body) {
+	this.request.post("https://steamcommunity.com/login/getrsakey/", {
+		"form": {
+			"username": details.accountName
+		},
+		"headers": mobileHeaders
+	}, function(err, response, body) {
 		if(err) {
 			callback(err);
 			return;
@@ -85,7 +92,8 @@ SteamCommunity.prototype.login = function(details, callback) {
 		self.request.post({
 			"uri": "https://steamcommunity.com/login/dologin/",
 			"json": true,
-			"form": form
+			"form": form,
+			"headers": mobileHeaders
 		}, function(err, response, body) {
 			if(self._checkHttpError(err, response, callback)) {
 				return;

--- a/index.js
+++ b/index.js
@@ -39,7 +39,6 @@ function SteamCommunity(localAddress) {
 
 	this._jar.setCookie(Request.cookie("mobileClientVersion=0 (2.1.3)"), "https://steamcommunity.com");
 	this._jar.setCookie(Request.cookie("mobileClient=android"), "https://steamcommunity.com");
-	this._jar.setCookie(Request.cookie("Steam_Language=english"), "https://steamcommunity.com");
 }
 
 SteamCommunity.prototype.login = function(details, callback) {


### PR DESCRIPTION
This allows us to grab the oAuth token when logging in. Once change to existing functionality is that `body.transfer_parameters` no longer exists, so we have to grab the Steam ID from `oAuth.steamid`.

If the user has logged in through other means (steam-user, etc.), they'll still have to get their oAuth token via the web chat.

Most of this comes from https://github.com/geel9/SteamAuth, just translated into Node.