### PR TITLE
feat(trade-confirmations): add trade confirmation functionality

### DIFF
--- a/components/tradeconfirmations.js
+++ b/components/tradeconfirmations.js
@@ -1,0 +1,122 @@
+var SteamCommunity = require('../index.js');
+var SteamTotp = require('steam-totp');
+var Crypto = require('crypto');
+var ByteBuffer = require('bytebuffer');
+
+SteamCommunity.prototype.getConfirmations = function(secret, offset, callback) {
+  var url = this._generateConfirmationUrl(secret, offset);
+  var self = this;
+  return this.request.get(url, function(err, resp, body) {
+    if (err) {
+      return err;
+    }
+
+    var toConfirm = [];
+
+    var idRegex = /data-confid="(\d+)"/g;
+    var keyRegex = /data-key="(\d+)"/g;
+    var descRegex = /<div>((Confirm|Trade with|Sell -) .+)<\/div>/g;
+    while(true) {
+      try {
+        var id = idRegex.exec(body);
+        var key = keyRegex.exec(body);
+        var desc = descRegex.exec(body);
+
+        if (!id){
+          break;
+        }
+
+        toConfirm.push({ id: id[1], key: key[1], desc: desc[1] });
+        }
+      catch (e) {
+        callback(e);
+      }
+    }
+
+
+    callback(null, toConfirm);
+  });
+};
+
+SteamCommunity.prototype.confirmTrade = function(confirmation, secret, callback) {
+  this._sendConfirmationRequest(confirmation, secret, 'allow', callback);
+};
+
+SteamCommunity.prototype.cancelTrade = function(confirmation, secret, callback) {
+  this._sendConfirmationRequest(confirmation, secret, 'cancel', callback);
+};
+
+SteamCommunity.prototype._sendConfirmationRequest = function(confirmation, secret, op, callback) {
+  var url = 'https://steamcommunity.com/mobileconf/ajaxop';
+  var query = "?op=" + op + "&";
+  query += this._generateConfirmationQueryParams(secret, op);
+  query += "&cid=" + confirmation.id + "&ck=" + confirmation.key;
+  url += query;
+
+  this.request.get(url, function(err, resp, body) {
+    if (err) {
+      return err;
+    }
+
+    callback(body.success);
+  });
+};
+
+SteamCommunity.prototype._generateConfirmationUrl = function(secret, offset) {
+  var endpoint = 'https://steamcommunity.com/mobileconf/conf?';
+  return endpoint + this._generateConfirmationQueryParams(secret, 'conf');
+};
+
+SteamCommunity.prototype._generateConfirmationQueryParams = function(secret, tag, offset) {
+  offset = offset || 0;
+  var deviceID = require('crypto').createHash('sha1');
+  deviceID.update(Math.random().toString());
+  deviceID = deviceID.digest('hex');
+
+  var time = Math.floor(new Date() / 1000) + offset;
+
+  return 'p=' + deviceID + '&a=' + this.steamID.toString() + '&k=' + this._generateConfirmationHash(secret, tag, time) + '&t=' + time + '&m=android&tag=' + tag;
+};
+
+SteamCommunity.prototype._generateConfirmationHash = function(secret, tag, time) {
+  var secretBuffer = bufferizeSecret(secret);
+
+  var n2 = 8;
+
+  if (tag) {
+    if (tag.length > 32) {
+      n = 8 + 32;
+    }
+    else {
+      n2 = 8 + tag.length;
+    }
+  }
+
+  var buffer = new Buffer(n2);
+  buffer.writeUInt32BE(0, 0);
+  buffer.writeUInt32BE(time, 4);
+
+  if (tag) {
+    ByteBuffer.fromUTF8(tag).toBuffer().copy(buffer, 8, 0, n2 - 8);
+  }
+
+  var hmac = Crypto.createHmac('sha1', secretBuffer);
+  hmac = hmac.update(buffer).digest();
+  var encodedData = hmac.toString('base64');
+  return escape(encodedData);
+
+};
+
+function bufferizeSecret(secret) {
+  if(typeof secret === 'string') {
+    // Check if it's hex
+    if(secret.match(/[0-9a-f]{40}/i)) {
+      return new Buffer(secret, 'hex');
+    } else {
+      // Looks like it's base64
+      return new Buffer(secret, 'base64');
+    }
+  }
+
+  return secret;
+}

--- a/index.js
+++ b/index.js
@@ -14,18 +14,32 @@ function SteamCommunity(localAddress) {
 	this._captchaGid = -1;
 	this.chatState = SteamCommunity.ChatState.Offline;
 
-	var defaults = {"jar": this._jar, "timeout": 50000};
+	var defaults = {
+		"jar": this._jar,
+		"timeout": 50000,
+		"headers": {
+			"X-Requested-With": "com.valvesoftware.android.steam.community",
+			"referer": "https://steamcommunity.com/mobilelogin?oauth_client_id=DE45CD61&oauth_scope=read_profile%20write_profile%20read_client%20write_client",
+			"user-agent": "Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; Google Nexus 4 - 4.1.1 - API 16 - 768x1280 Build/JRO03S) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30",
+			"accept": "text/javascript, text/html, application/xml, text/xml, */*"
+		}
+	}
+
 	if(localAddress) {
 		defaults.localAddress = localAddress;
 	}
 
 	this.request = Request.defaults(defaults);
-	
-	// English
+
+
 	this._jar.setCookie(Request.cookie('Steam_Language=english'), 'https://steamcommunity.com');
 
 	// UTC
 	this._jar.setCookie(Request.cookie('timezoneOffset=0,0'), 'https://steamcommunity.com');
+
+	this._jar.setCookie(Request.cookie("mobileClientVersion=0 (2.1.3)"), "https://steamcommunity.com");
+	this._jar.setCookie(Request.cookie("mobileClient=android"), "https://steamcommunity.com");
+	this._jar.setCookie(Request.cookie("Steam_Language=english"), "https://steamcommunity.com");
 }
 
 SteamCommunity.prototype.login = function(details, callback) {
@@ -335,6 +349,7 @@ require('./components/users.js');
 require('./components/inventoryhistory.js');
 require('./components/webapi.js');
 require('./components/twofactor.js');
+require('./components/tradeconfirmations.js');
 require('./classes/CMarketItem.js');
 require('./classes/CMarketSearchResult.js');
 require('./classes/CSteamGroup.js');

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 	},
 	"dependencies": {
 		"request":			"^2.61.0",
+    "bytebuffer": "^5.0.0",
 		"node-bignumber":	"^1.2.1",
 		"steamid":			"^0.3.1",
 		"xml2js":			"^0.4.11",


### PR DESCRIPTION
Quick implementation of https://github.com/geel9/SteamAuth.

It doesn't have all the functionality, but getting/accepting/declining trade requests is all good