### PR TITLE
Fixed crash when handling an inventory issue

### DIFF
--- a/components/users.js
+++ b/components/users.js
@@ -262,7 +262,12 @@ SteamCommunity.prototype.getUserInventory = function(userID, appID, contextID, t
 			}
 
 			if(!body || !body.success || !body.rgInventory || !body.rgDescriptions || !body.rgCurrency) {
-				callback(new Error(body.Error || "Malformed response"));
+				if(body) {
+					callback(new Error(body.error || "Malformed response"));
+				} else {
+					callback(new Error("Malformed response"));
+				}
+				
 				return;
 			}
 

--- a/components/users.js
+++ b/components/users.js
@@ -263,7 +263,7 @@ SteamCommunity.prototype.getUserInventory = function(userID, appID, contextID, t
 
 			if(!body || !body.success || !body.rgInventory || !body.rgDescriptions || !body.rgCurrency) {
 				if(body) {
-					callback(new Error(body.error || "Malformed response"));
+					callback(new Error(body.Error || "Malformed response"));
 				} else {
 					callback(new Error("Malformed response"));
 				}


### PR DESCRIPTION
This should fix a crash I've been occasionally experiencing, where `body` is undefined. The stack trace for this crash:

```
/bots/node_modules/steamcommunity/components/users.js:265
                                callback(new Error(body.Error || "Malformed response"));
                                                       ^

TypeError: Cannot read property 'Error' of undefined
    at Request._callback (/bots/node_modules/steamcommunity/components/users.js:265:28)
    at Request.self.callback (/bots/node_modules/steamcommunity/node_modules/request/request.js:199:22)
    at emitTwo (events.js:100:13)
    at Request.emit (events.js:185:7)
    at Request.<anonymous> (/bots/node_modules/steamcommunity/node_modules/request/request.js:1036:10)
    at emitOne (events.js:95:20)
    at Request.emit (events.js:182:7)
    at IncomingMessage.<anonymous> (/bots/node_modules/steamcommunity/node_modules/request/request.js:963:12)
    at emitNone (events.js:85:20)
    at IncomingMessage.emit (events.js:179:7)
```