### PR TITLE
Update getInventoryContent()

### DIFF
--- a/components/users.js
+++ b/components/users.js
@@ -303,7 +303,7 @@ SteamCommunity.prototype.getUserInventory = function(userID, appID, contextID, t
 						callback(new Error("Malformed response"));
 					}
 						
-					callback(new Error(body.Error || "Malformed response"));
+					callback(new Error("Malformed response"));
 				} else {
 					callback(new Error("Malformed response"));
 				}

--- a/components/users.js
+++ b/components/users.js
@@ -295,6 +295,14 @@ SteamCommunity.prototype.getUserInventory = function(userID, appID, contextID, t
 
 			if (!body || !body.success || !body.rgInventory || !body.rgDescriptions || !body.rgCurrency) {
 				if (body) {
+					if (body.Error) {
+						callback(new Error(body.Error));
+					} else if (body.total_inventory_count == 0) {
+						callback(new Error("Empty inventory"));
+					} else {
+						callback(new Error("Malformed response"));
+					}
+						
 					callback(new Error(body.Error || "Malformed response"));
 				} else {
 					callback(new Error("Malformed response"));


### PR DESCRIPTION
Returns new Error("Empty Inventory") instead of Malformed response if inventory is empty

See the issue in [node-steam-tradeoffer-manager #201](https://github.com/DoctorMcKay/node-steam-tradeoffer-manager/issues/201)