### PR TITLE
Check if instance is logged in before comparing steamids (fixes #164)

### DIFF
--- a/components/users.js
+++ b/components/users.js
@@ -368,7 +368,7 @@ SteamCommunity.prototype.getUserInventoryContents = function(userID, appID, cont
 			if (err) {
 				if (err.message == "HTTP error 403" && body === null) {
 					// 403 with a body of "null" means the inventory/profile is private.
-					if(userID.getSteamID64() == self.steamID.getSteamID64()) {
+					if (self.steamID && userID.getSteamID64() == self.steamID.getSteamID64()) {
 						// We can never get private profile error for our own inventory!
 						self._notifySessionExpired(err);
 					}


### PR DESCRIPTION
I don't think the module has `logged` property, so I'm using `steamID` to check if the instance is logged in.