### PR TITLE
Fix infinite loop in getWebApiKey

### DIFF
--- a/components/webapi.js
+++ b/components/webapi.js
@@ -14,6 +14,10 @@ SteamCommunity.prototype.getWebApiKey = function(domain, callback) {
 		if(body.match(/<h2>Access Denied<\/h2>/)) {
 			return callback(new Error("Access Denied"));
 		}
+		
+		if(body.match(/You must have a validated email address to create a Steam Web API key./)) {
+			return callback(new Error("You must have a validated email address to create a Steam Web API key."));
+		}
 
 		var match = body.match(/<p>Key: ([0-9A-F]+)<\/p>/);
 		if(match) {


### PR DESCRIPTION
Fix infinite loop in getWebApiKey when trying to get web api key on account without email address confirmed