### PR TITLE
Add tradable date to CEconItem

### DIFF
--- a/classes/CEconItem.js
+++ b/classes/CEconItem.js
@@ -70,6 +70,16 @@ function CEconItem(item, description, contextID) {
 		this.actions = [];
 	}
 
+	if (!this.tradable && this.owner_descriptions) {
+		var tradableDescription = this.owner_descriptions.find((description) => {
+			return description.value && description.value.startsWith("Tradable After ");
+		});
+
+		if (tradableDescription) {
+			this.tradable_date = new Date(tradableDescription.value.replace(/[()]/g, ""));
+		}
+	}
+
 	 delete this.currency;
 }
 


### PR DESCRIPTION
Adds an `item.tradable_date` property to CEconItem containing the date at which the item becomes tradable.