### PR TITLE
Added the possibility to edit showcases

### DIFF
--- a/components/profile.js
+++ b/components/profile.js
@@ -53,11 +53,29 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 			return;
 		}
 
+		var values = {};
 		var formd = form.serializeArray();
-		if (formd[15].name != "profile_background") {
-			formd.splice(15, 0, {"name": "profile_background",	"value": ""});
+		var i = 0;
+		form.serializeArray().forEach(function (item) {
+			values[item.name] = i;
+			i++;
+		});
+		var out = [];
+		var requiredvalues = ["sessionID", "type", "weblink_1_title", "weblink_1_url", "weblink_2_title", "weblink_2_url", "weblink_3_title", "weblink_3_url", "personaName", "real_name", "country", "state", "city", "customURL", "summary", "profile_background", "favorite_badge_badgeid", "favorite_badge_communityitemid", "primary_group_steamid"];
+
+		for (var i = 0; i < 18; i++) {
+			if (values.hasOwnProperty(requiredvalues[i])) {
+				out.push({
+					"name": requiredvalues[i],
+					"value": formd[values[requiredvalues[i]]].value
+				});
+			} else {
+				out.push({
+					"name": requiredvalues[i],
+					"value": ""
+				});
+			}
 		}
-		var out = [].concat(formd.slice(0,19));
 
 		for(var i in settings) {
 			if(!settings.hasOwnProperty(i)) {
@@ -66,81 +84,48 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 
 			switch(i) {
 				case 'name':
-					out[8] = {
-						"name": formd[8].name,
-						"value": settings[i]
-					};
+					out[8].value = settings[i];
 					break;
 
 				case 'realName':
-					out[9] = {
-						"name": formd[9].name,
-						"value": settings[i]
-					};
+					out[9].value = settings[i];
 					break;
 
 				case 'summary':
-					out[14] = {
-						"name": formd[14].name,
-						"value": settings[i]
-					};
+					out[14].value = settings[i];
 					break;
 
 				case 'country':
-					out[10] = {
-						"name": formd[10].name,
-						"value": settings[i]
-					};
+					out[10].value = settings[i];
 					break;
 
 				case 'state':
-					out[11] = {
-						"name": formd[11].name,
-						"value": settings[i]
-					};
+					out[11].value = settings[i];
 					break;
 
 				case 'city':
-					out[12] = {
-						"name": formd[12].name,
-						"value": settings[i]
-					};
+					out[12].value = settings[i];
 					break;
 
 				case 'customURL':
-					out[13] = {
-						"name": formd[13].name,
-						"value": settings[i]
-					};
+					out[13].value = settings[i];
 					break;
 
 				case 'background':
 					// The assetid of our desired profile background
-					out[15] = {
-						"name": formd[15].name,
-						"value": settings[i]
-					};
+					out[15].value = settings[i];
 					break;
 
 				case 'featuredBadge':
 					// Currently, game badges aren't supported
-						out[16] = {
-							"name": formd[16].name,
-							"value": settings[i]
-						};
+						out[16].value = settings[i];
 					break;
 
 				case 'primaryGroup':
 					if (typeof settings[i] === 'object' && settings[i].getSteamID64) {
-						out[18] = {
-							"name": formd[18].name,
-							"value": settings[i].getSteamID64()
-						};
+						out[18].value = settings[i].getSteamID64();
 					} else {
-						out[18] = {
-							"name": formd[18].name,
-							"value": new SteamID(settings[i]).getSteamID64()
-						};
+						out[18].value = new SteamID(settings[i]).getSteamID64();
 					}
 
 					break;

--- a/components/profile.js
+++ b/components/profile.js
@@ -131,7 +131,7 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 					break;
 
 				case 'showcases':
-					for (var t in settings[i]) {
+					for (var type in settings[i]) {
 						//Variable used to easily make request to`ajaxsetshowcaseconfig` for showcases like trade, items, ...
 						var showcaseconfig = {
 							"supplied": false,
@@ -140,7 +140,7 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 							"itemarray": []
 						};
 
-						switch (settings[i][t].showcase) {
+						switch (settings[i][type].showcase) {
 
 							case 'infobox':
 								out.push({
@@ -149,11 +149,11 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 								});
 								out.push({
 									"name": "rgShowcaseConfig[8][0][title]",
-									"value": settings[i][t]["values"]["title"]
+									"value": settings[i][type]["values"]["title"]
 								});
 								out.push({
 									"name": "rgShowcaseConfig[8][0][notes]",
-									"value": settings[i][t]["values"]["notes"]
+									"value": settings[i][type]["values"]["notes"]
 								});
 								break;
 
@@ -165,7 +165,7 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 								for (var n = 0; n < 4; n++) {
 									out.push({
 										"name": "rgShowcaseConfig[13][" + n + "][publishedfileid]",
-										"value": settings[i][t]["values"][n] || ""
+										"value": settings[i][type]["values"][n] || ""
 									});
 								}
 								break;
@@ -177,14 +177,14 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 								});
 								out.push({
 									"name": "rgShowcaseConfig[4][6][notes]",
-									"value": settings[i][t]["values"]["notes"]
+									"value": settings[i][type]["values"]["notes"]
 								});
 
-								if (settings[i][t]["values"].hasOwnProperty("items")) {
+								if (settings[i][type]["values"].hasOwnProperty("items")) {
 									showcaseconfig.supplied = true;
 									showcaseconfig.numberofrequests = 6;
 									showcaseconfig.showcasetype = 4;
-									showcaseconfig.itemarray = settings[i][t]["values"]["items"];
+									showcaseconfig.itemarray = settings[i][type]["values"]["items"];
 								}
 								break;
 
@@ -194,11 +194,11 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 									"value": "3"
 								});
 
-								if (settings[i][t]["values"].hasOwnProperty("items")) {
+								if (settings[i][type]["values"].hasOwnProperty("items")) {
 									showcaseconfig.supplied = true;
 									showcaseconfig.numberofrequests = 10;
 									showcaseconfig.showcasetype = 3;
-									showcaseconfig.itemarray = settings[i][t]["values"]["items"];
+									showcaseconfig.itemarray = settings[i][type]["values"]["items"];
 								}
 								break;
 
@@ -209,7 +209,7 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 								});
 								out.push({
 									"name": "rgShowcaseConfig[6][0][appid]",
-									"value": settings[i][t]["values"]["appid"]
+									"value": settings[i][type]["values"]["appid"]
 								});
 								break;
 
@@ -221,14 +221,14 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 								var styles = ["rare","selected",null,"recent","random"];
 								out.push({
 									"name": "profile_showcase_style_5",
-									"value": styles.indexOf(settings[i][t]["values"]["style"])
+									"value": styles.indexOf(settings[i][type]["values"]["style"])
 								});
 
-								if (settings[i][t]["values"].hasOwnProperty("badges")){
+								if (settings[i][type]["values"].hasOwnProperty("badges")){
 									for(var n = 0; n < 6; n++){
 										var defaultval = ["", "", ""];
-										if (settings[i][t]["values"]["badges"][n] != undefined) {
-											defaultval = [settings[i][t]["values"]["badges"][n]["badgeid"], settings[i][t]["values"]["badges"][n]["appid"], settings[i][t]["values"]["badges"][n]["border_color"]];
+										if (settings[i][type]["values"]["badges"][n] != undefined) {
+											defaultval = [settings[i][type]["values"]["badges"][n]["badgeid"], settings[i][type]["values"]["badges"][n]["appid"], settings[i][type]["values"]["badges"][n]["border_color"]];
 										}
 										out.push({
 											"name": "rgShowcaseConfig[5][" + n + "][badgeid]",
@@ -262,7 +262,7 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 								for (var n = 0; n < 4; n++) {
 									out.push({
 										"name": "rgShowcaseConfig[7][" + n + "][publishedfileid]",
-										"value": settings[i][t]["values"][n] || ""
+										"value": settings[i][type]["values"][n] || ""
 									});
 								}
 								break;
@@ -272,15 +272,15 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 									"name": "profile_showcase[]",
 									"value": "9"
 								});
-								if (typeof settings[i][t]["values"]["groupid"] === 'object' && settings[i][t]["values"]["groupid"].getSteamID64) {
+								if (typeof settings[i][type]["values"]["groupid"] === 'object' && settings[i][type]["values"]["groupid"].getSteamID64) {
 									out.push({
 										"name": "rgShowcaseConfig[9][0][accountid]",
-										"value": settings[i][t]["values"]["groupid"].getSteamID64()
+										"value": settings[i][type]["values"]["groupid"].getSteamID64()
 									});
 								} else {
 									out.push({
 										"name": "rgShowcaseConfig[9][0][accountid]",
-										"value": new SteamID(settings[i][t]["values"]["groupid"]).getSteamID64()
+										"value": new SteamID(settings[i][type]["values"]["groupid"]).getSteamID64()
 									});
 								}
 								break;
@@ -292,7 +292,7 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 								});
 								out.push({
 									"name": "rgShowcaseConfig[10][0][appid]",
-									"value": settings[i][t]["values"]["appid"]
+									"value": settings[i][type]["values"]["appid"]
 								});
 								break;
 
@@ -303,11 +303,11 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 								});
 								out.push({
 									"name": "rgShowcaseConfig[11][0][appid]",
-									"value": settings[i][t]["values"]["appid"]
+									"value": settings[i][type]["values"]["appid"]
 								});
 								out.push({
 									"name": "rgShowcaseConfig[11][0][publishedfileid]",
-									"value": settings[i][t]["values"]["publishedfileid"]
+									"value": settings[i][type]["values"]["publishedfileid"]
 								});
 								break;
 
@@ -318,11 +318,11 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 								});
 								out.push({
 									"name": "rgShowcaseConfig[15][0][appid]",
-									"value": settings[i][t]["values"]["appid"]
+									"value": settings[i][type]["values"]["appid"]
 								});
 								out.push({
 									"name": "rgShowcaseConfig[15][0][publishedfileid]",
-									"value": settings[i][t]["values"]["publishedfileid"]
+									"value": settings[i][type]["values"]["publishedfileid"]
 								});
 								break;
 
@@ -331,11 +331,11 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 									"name": "profile_showcase[]",
 									"value": "17"
 								});
-								if (settings[i][t]["values"].hasOwnProperty("achievements")) {
+								if (settings[i][type]["values"].hasOwnProperty("achievements")) {
 									for (var n = 0; n < 7; n++) {
 										var defaultval = ["", ""];
-										if (settings[i][t]["values"]["achievements"][n] != undefined) {
-											defaultval = [settings[i][t]["values"]["achievements"][n]["appid"], settings[i][t]["values"]["achievements"][n]["title"]];
+										if (settings[i][type]["values"]["achievements"][n] != undefined) {
+											defaultval = [settings[i][type]["values"]["achievements"][n]["appid"], settings[i][type]["values"]["achievements"][n]["title"]];
 										}
 										out.push({
 											"name": "rgShowcaseConfig[17][" + n + "][appid]",
@@ -355,11 +355,11 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 										"value": "2"
 									});
 
-									if (settings[i][t]["values"].hasOwnProperty("games")) {
+									if (settings[i][type]["values"].hasOwnProperty("games")) {
 										showcaseconfig.supplied = true;
 										showcaseconfig.numberofrequests = 4;
 										showcaseconfig.showcasetype = 2;
-										showcaseconfig.itemarray = settings[i][t]["values"]["games"];
+										showcaseconfig.itemarray = settings[i][type]["values"]["games"];
 									}
 									break;
 
@@ -371,8 +371,8 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 
 									for (var n = 0; n < 4; n++) {
 										var defaultval = ["", ""];
-										if (settings[i][t]["values"][n] != undefined) {
-											defaultval = [settings[i][t]["values"][n]["appid"], settings[i][t]["values"][n]["publishedfileid"]];
+										if (settings[i][type]["values"][n] != undefined) {
+											defaultval = [settings[i][type]["values"][n]["appid"], settings[i][type]["values"][n]["publishedfileid"]];
 										}
 										out.push({
 											"name": "rgShowcaseConfig[16][" + n + "][appid]",
@@ -393,8 +393,8 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 
 									for (var n = 0; n < 5; n++) {
 										var defaultval = ["", ""];
-										if (settings[i][t]["values"][n] != undefined) {
-											defaultval = [settings[i][t]["values"][n]["appid"], settings[i][t]["values"][n]["publishedfileid"]];
+										if (settings[i][type]["values"][n] != undefined) {
+											defaultval = [settings[i][type]["values"][n]["appid"], settings[i][type]["values"][n]["publishedfileid"]];
 										}
 										out.push({
 											"name": "rgShowcaseConfig[12][" + n + "][appid]",
@@ -432,7 +432,7 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 
 									}
 
-									self._myProfile("ajaxsetshowcaseconfig", requestdata, function (err, response, body) {
+									setTimeout(self._myProfile.bind(self,"ajaxsetshowcaseconfig", requestdata, function (err, response, body) {
 										if (settings.customURL) {
 											delete selfe._profileURL;
 										}
@@ -462,7 +462,7 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 										if (callback) {
 											callback(null);
 										}
-									});
+									}), n * 1500);
 								}
 
 							}

--- a/components/profile.js
+++ b/components/profile.js
@@ -363,6 +363,7 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 
 									}.bind(errorcontrol)), num_of_requests * 1500);
 								}
+							}
 						}
 
 					}

--- a/components/profile.js
+++ b/components/profile.js
@@ -1,7 +1,6 @@
 const Cheerio = require('cheerio');
 const FS = require('fs');
 const SteamID = require('steamid');
-const Param = require('jquery-param');
 
 const Helpers = require('./helpers.js');
 const SteamCommunity = require('../index.js');
@@ -473,7 +472,13 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 			}
 		}
 
-		self._myProfile("edit", Param(out), function(err, response, body) {
+		var parameters = [];
+		for(let i = 0; i < out.length; i++){
+			parameters.push(encodeURIComponent(out[i].name) + "=" + encodeURIComponent(out[i].value));
+		}
+		parameters = parameters.join("&");
+
+		self._myProfile("edit", parameters, function(err, response, body) {
 			if (settings.customURL) {
 				delete self._profileURL;
 			}

--- a/components/profile.js
+++ b/components/profile.js
@@ -330,7 +330,7 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 									}
 									break;
 
-								case 'ownguides':
+								case 'ownworkshop':
 									values["profile_showcase[12]"] = 12;
 
 									if (settings[i][type].hasOwnProperty("values")) {

--- a/components/profile.js
+++ b/components/profile.js
@@ -58,6 +58,8 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 			values[item.name] = item.value;
 		});
 
+		var maxshowcases = $(".profile_showcase_selector").length;
+
 		for (var i in settings) {
 			if (!settings.hasOwnProperty(i)) {
 				continue;
@@ -112,260 +114,270 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 
 
 				case 'showcases':
-					var num_of_requests = 0;
+					var numofrequests = 0;
+
 					//When supplying a new showcases array, remove the old showcase (order)
 					for (var val in values) {
 						if (val.indexOf("[") !== -1) {
 							if (val.split("[")[0] == "profile_showcase")
 								delete values[val];
 						}
-
 					}
+
 					for (var type in settings[i]) {
-						//Variable used to easily make request to`ajaxsetshowcaseconfig` for showcases like trade, items, ...
-						var showcaseconfig = {
-							"supplied": false,
-							"numberofrequests": 0,
-							"showcasetype": 0,
-							"itemarray": []
-						};
-						//Controls if the callback function is called when a request changing f.e. a single item or game in a showcase fails
-						var errorcontrol = {
-							error: false,
-							showerrors: false
-						};
-						if (settings[i][type].hasOwnProperty("values")) {
-							if (settings[i][type]["values"].hasOwnProperty("showshowcaseconfigerrors")) {
-								errorcontrol.showerrors = settings[i][type]["values"]["showshowcaseconfigerrors"];
+
+						if(maxshowcases > 0){
+
+							maxshowcases--;
+
+							//Variable used to easily make request to`ajaxsetshowcaseconfig` for showcases like trade, items, ...
+							var showcaseconfig = {
+								"supplied": false,
+								"numberofrequests": 0,
+								"showcasetype": 0,
+								"itemarray": []
+							};
+
+							//Controls if the callback function is called when a request changing f.e. a single item or game in a showcase fails
+							var errorcontrol = {
+								"error": false,
+								"showerrors": false
+							};
+
+							if (settings[i][type].hasOwnProperty("values")) {
+								if (settings[i][type]["values"].hasOwnProperty("showshowcaseconfigerrors")) {
+									errorcontrol["showerrors"] = settings[i][type]["values"]["showshowcaseconfigerrors"];
+								}
 							}
-						}
-						switch (settings[i][type].showcase) {
 
-							case 'infobox':
-								values["profile_showcase[8]"] = 8;
+							switch (settings[i][type].showcase) {
 
-								if (settings[i][type].hasOwnProperty("values")){
-									if (settings[i][type]["values"].hasOwnProperty("title")){
-										values["rgShowcaseConfig[8][0][title]"] = settings[i][type]["values"]["title"];
-									}
-									if (settings[i][type]["values"].hasOwnProperty("notes")) {
-										values["rgShowcaseConfig[8][0][notes]"] = settings[i][type]["values"]["notes"];
-									}
-								}
+								case 'infobox':
+									values["profile_showcase[8]"] = 8;
 
-								break;
-
-							case 'artwork':
-								values["profile_showcase[13]"] = 13;
-
-								if (settings[i][type].hasOwnProperty("values")) {
-									for (var n = 0; n < 4; n++) {
-										values["profile_showcase[13][" + n + "][publishedfileid]"] = settings[i][type]["values"][n] || "";
-									}
-								}
-								break;
-
-							case 'trade':
-								values["profile_showcase[4]"] = 4;
-
-								if (settings[i][type].hasOwnProperty("values")) {
-
-									if (settings[i][type]["values"].hasOwnProperty("notes")) {
-										values["rgShowcaseConfig[4][6][notes]"] = settings[i][type]["values"]["notes"];
+									if (settings[i][type].hasOwnProperty("values")){
+										if (settings[i][type]["values"].hasOwnProperty("title")){
+											values["rgShowcaseConfig[8][0][title]"] = settings[i][type]["values"]["title"];
+										}
+										if (settings[i][type]["values"].hasOwnProperty("notes")) {
+											values["rgShowcaseConfig[8][0][notes]"] = settings[i][type]["values"]["notes"];
+										}
 									}
 
-									if (settings[i][type]["values"].hasOwnProperty("items")) {
-										showcaseconfig.supplied = true;
-										showcaseconfig.numberofrequests = 6;
-										showcaseconfig.showcasetype = 4;
-										showcaseconfig.itemarray = settings[i][type]["values"]["items"];
+									break;
+
+								case 'artwork':
+									values["profile_showcase[13]"] = 13;
+
+									if (settings[i][type].hasOwnProperty("values")) {
+										for (var n = 0; n < 4; n++) {
+											values["profile_showcase[13][" + n + "][publishedfileid]"] = settings[i][type]["values"][n] || "";
+										}
 									}
-								}
-								break;
+									break;
 
-							case 'items':
-								values["profile_showcase[3]"] = 3;
+								case 'trade':
+									values["profile_showcase[4]"] = 4;
 
-								if (settings[i][type].hasOwnProperty("values") && settings[i][type]["values"].hasOwnProperty("items")) {
-									showcaseconfig.supplied = true;
-									showcaseconfig.numberofrequests = 10;
-									showcaseconfig.showcasetype = 3;
-									showcaseconfig.itemarray = settings[i][type]["values"]["items"];
-								}
-								break;
+									if (settings[i][type].hasOwnProperty("values")) {
 
-							case 'game':
-								values["profile_showcase[6]"] = 6;
+										if (settings[i][type]["values"].hasOwnProperty("notes")) {
+											values["rgShowcaseConfig[4][6][notes]"] = settings[i][type]["values"]["notes"];
+										}
 
-								if (settings[i][type].hasOwnProperty("values")) {
-									values["rgShowcaseConfig[6][0][appid]"] = settings[i][type]["values"];
-								}
-								break;
-
-							case 'badge':
-								values["profile_showcase[5]"] = 5;
-
-								if (settings[i][type].hasOwnProperty("values")) {
-
-									if (settings[i][type]["values"].hasOwnProperty("style")) {
-										var styles = ["rare", "selected", null, "recent", "random"];
-										values["profile_showcase_style_5"] = styles.indexOf(settings[i][type]["values"]["style"]);
+										if (settings[i][type]["values"].hasOwnProperty("items")) {
+											showcaseconfig["supplied"] = true;
+											showcaseconfig["numberofrequests"] = 6;
+											showcaseconfig["showcasetype"] = 4;
+											showcaseconfig["itemarray"] = settings[i][type]["values"]["items"];
+										}
 									}
+									break;
 
-									if (settings[i][type]["values"].hasOwnProperty("badges")) {
-										var types = ["badgeid", "appid", "border_color"];
-										for (var n = 0; n < 6; n++) {
-											for (var m = 0; m < 3; m++){
-												if (settings[i][type]["values"]["badges"][n] != undefined) {
-													if (settings[i][type]["values"]["badges"][n].hasOwnProperty(types[m])){
-														values["rgShowcaseConfig[5][" + n + "][" + types[m] + "]"] = settings[i][type]["values"]["badges"][n][types[m]] || values["rgShowcaseConfig[5][" + n + "][" + types[m] + "]"] || "";
+								case 'items':
+									values["profile_showcase[3]"] = 3;
+
+									if (settings[i][type].hasOwnProperty("values") && settings[i][type]["values"].hasOwnProperty("items")) {
+										showcaseconfig["supplied"] = true;
+										showcaseconfig["numberofrequests"] = 10;
+										showcaseconfig["showcasetype"] = 3;
+										showcaseconfig["itemarray"] = settings[i][type]["values"]["items"];
+									}
+									break;
+
+								case 'game':
+									values["profile_showcase[6]"] = 6;
+
+									if (settings[i][type].hasOwnProperty("values")) {
+										values["rgShowcaseConfig[6][0][appid]"] = settings[i][type]["values"];
+									}
+									break;
+
+								case 'badge':
+									values["profile_showcase[5]"] = 5;
+
+									if (settings[i][type].hasOwnProperty("values")) {
+
+										if (settings[i][type]["values"].hasOwnProperty("style")) {
+											var styles = ["rare", "selected", null, "recent", "random"];
+											values["profile_showcase_style_5"] = styles.indexOf(settings[i][type]["values"]["style"]);
+										}
+
+										if (settings[i][type]["values"].hasOwnProperty("badges")) {
+											var types = ["badgeid", "appid", "border_color"];
+											for (var n = 0; n < 6; n++) {
+												for (var t in type){
+													if (settings[i][type]["values"]["badges"][n] != undefined) {
+														if (settings[i][type]["values"]["badges"][n].hasOwnProperty(types[t])){
+															values["rgShowcaseConfig[5][" + n + "][" + types[t] + "]"] = settings[i][type]["values"]["badges"][n][types[t]] || values["rgShowcaseConfig[5][" + n + "][" + types[t] + "]"] || "";
+														}
 													}
 												}
 											}
 										}
 									}
-								}
 
-								break;
+									break;
 
-							case 'rareachievements':
-								values["profile_showcase[1]"] = 1;
-								break;
+								case 'rareachievements':
+									values["profile_showcase[1]"] = 1;
+									break;
 
-							case 'screenshot':
-								values["profile_showcase[7]"] = 7;
+								case 'screenshot':
+									values["profile_showcase[7]"] = 7;
 
-								if (settings[i][type].hasOwnProperty("values")) {
-									for (var n = 0; n < 4; n++) {
-										if (settings[i][type]["values"][n] != undefined) {
-											values["rgShowcaseConfig[7][" + n + "][publishedfileid]"] = settings[i][type]["values"][n];
+									if (settings[i][type].hasOwnProperty("values")) {
+										for (var n = 0; n < 4; n++) {
+											if (settings[i][type]["values"][n] != undefined) {
+												values["rgShowcaseConfig[7][" + n + "][publishedfileid]"] = settings[i][type]["values"][n];
+											}
 										}
 									}
-								}
-								break;
+									break;
 
-							case 'group':
-								values["profile_showcase[9]"] = 9;
+								case 'group':
+									values["profile_showcase[9]"] = 9;
 
-								if (settings[i][type].hasOwnProperty("values")) {
-									if (typeof settings[i][type]["values"] === 'object' && settings[i][type]["values"].getSteamID64) {
-										values["rgShowcaseConfig[9][0][accountid]"] = settings[i][type]["values"].getSteamID64();
-									} else {
-										values["rgShowcaseConfig[9][0][accountid]"] = new SteamID(settings[i][type]["values"]).getSteamID64();
-									}
-								}
-								break;
-
-							case 'review':
-								values["profile_showcase[10]"] = 10;
-
-								if (settings[i][type].hasOwnProperty("values")) {
-									values["rgShowcaseConfig[10][0][appid]"] = settings[i][type]["values"];
-								}
-								break;
-
-							case 'workshop':
-								values["profile_showcase[11]"] = 11;
-
-								if (settings[i][type].hasOwnProperty("values")) {
-									values["rgShowcaseConfig[11][0][appid]"] = settings[i][type]["values"]["appid"];
-									values["rgShowcaseConfig[11][0][publishedfileid]"] = settings[i][type]["values"]["publishedfileid"];
-								}
-								break;
-
-							case 'guide':
-								values["profile_showcase[15]"] = 15;
-
-								if (settings[i][type].hasOwnProperty("values")) {
-									values["rgShowcaseConfig[15][0][appid]"] = settings[i][type]["values"]["appid"];
-									values["rgShowcaseConfig[15][0][publishedfileid]"] = settings[i][type]["values"]["publishedfileid"];
-								}
-								break;
-
-							case 'achievements':
-								values["profile_showcase[17]"] = 17;
-
-								if (settings[i][type].hasOwnProperty("values") && settings[i][type]["values"].hasOwnProperty("achievements")) {
-									for (var n = 0; n < 7; n++) {
-										if (settings[i][type]["values"]["achievements"][n] != undefined) {
-											values["rgShowcaseConfig[17][" + n + "][appid]"] = settings[i][type]["values"]["achievements"][n]["appid"];
-											values["rgShowcaseConfig[17][" + n + "][title]"] = settings[i][type]["values"]["achievements"][n]["title"];
+									if (settings[i][type].hasOwnProperty("values")) {
+										if (typeof settings[i][type]["values"] === 'object' && settings[i][type]["values"].getSteamID64) {
+											values["rgShowcaseConfig[9][0][accountid]"] = settings[i][type]["values"].getSteamID64();
+										} else {
+											values["rgShowcaseConfig[9][0][accountid]"] = new SteamID(settings[i][type]["values"]).getSteamID64();
 										}
 									}
-								}
-								break;
+									break;
 
-							case 'games':
-								values["profile_showcase[2]"] = 2;
+								case 'review':
+									values["profile_showcase[10]"] = 10;
 
-								if (settings[i][type].hasOwnProperty("values") && settings[i][type]["values"].hasOwnProperty("games")) {
-									showcaseconfig.supplied = true;
-									showcaseconfig.numberofrequests = 4;
-									showcaseconfig.showcasetype = 2;
-									showcaseconfig.itemarray = settings[i][type]["values"]["games"];
-								}
-								break;
+									if (settings[i][type].hasOwnProperty("values")) {
+										values["rgShowcaseConfig[10][0][appid]"] = settings[i][type]["values"];
+									}
+									break;
 
-							case 'ownguides':
-								values["profile_showcase[16]"] = 16;
+								case 'workshop':
+									values["profile_showcase[11]"] = 11;
 
-								if (settings[i][type].hasOwnProperty("values")) {
-									for (var n = 0; n < 4; n++) {
-										if (settings[i][type]["values"][n] != undefined) {
-											values["rgShowcaseConfig[16][" + n + "][appid]"] = settings[i][type]["values"][n]["appid"];
-											values["rgShowcaseConfig[16][" + n + "][publishedfileid]"] = settings[i][type]["values"][n]["publishedfileid"];
+									if (settings[i][type].hasOwnProperty("values")) {
+										values["rgShowcaseConfig[11][0][appid]"] = settings[i][type]["values"]["appid"];
+										values["rgShowcaseConfig[11][0][publishedfileid]"] = settings[i][type]["values"]["publishedfileid"];
+									}
+									break;
+
+								case 'guide':
+									values["profile_showcase[15]"] = 15;
+
+									if (settings[i][type].hasOwnProperty("values")) {
+										values["rgShowcaseConfig[15][0][appid]"] = settings[i][type]["values"]["appid"];
+										values["rgShowcaseConfig[15][0][publishedfileid]"] = settings[i][type]["values"]["publishedfileid"];
+									}
+									break;
+
+								case 'achievements':
+									values["profile_showcase[17]"] = 17;
+
+									if (settings[i][type].hasOwnProperty("values") && settings[i][type]["values"].hasOwnProperty("achievements")) {
+										for (var n = 0; n < 7; n++) {
+											if (settings[i][type]["values"]["achievements"][n] != undefined) {
+												values["rgShowcaseConfig[17][" + n + "][appid]"] = settings[i][type]["values"]["achievements"][n]["appid"];
+												values["rgShowcaseConfig[17][" + n + "][title]"] = settings[i][type]["values"]["achievements"][n]["title"];
+											}
 										}
 									}
-								}
-								break;
+									break;
 
-							case 'ownguides':
-								values["profile_showcase[12]"] = 12;
-								if (settings[i][type].hasOwnProperty("values")) {
-									for (var n = 0; n < 5; n++) {
-										if (settings[i][type]["values"][n] != undefined) {
-											values["rgShowcaseConfig[12][" + n + "][appid]"] = settings[i][type]["values"][n]["appid"];
-											values["rgShowcaseConfig[12][" + n + "][publishedfileid]"] = settings[i][type]["values"][n]["publishedfileid"];
+								case 'games':
+									values["profile_showcase[2]"] = 2;
+
+									if (settings[i][type].hasOwnProperty("values") && settings[i][type]["values"].hasOwnProperty("games")) {
+										showcaseconfig["supplied"] = true;
+										showcaseconfig["numberofrequests"] = 4;
+										showcaseconfig["showcasetype"] = 2;
+										showcaseconfig["itemarray"] = settings[i][type]["values"]["games"];
+									}
+									break;
+
+								case 'ownguides':
+									values["profile_showcase[16]"] = 16;
+
+									if (settings[i][type].hasOwnProperty("values")) {
+										for (var n = 0; n < 4; n++) {
+											if (settings[i][type]["values"][n] != undefined) {
+												values["rgShowcaseConfig[16][" + n + "][appid]"] = settings[i][type]["values"][n]["appid"];
+												values["rgShowcaseConfig[16][" + n + "][publishedfileid]"] = settings[i][type]["values"][n]["publishedfileid"];
+											}
 										}
 									}
-								}
-								break;
-						}
+									break;
 
-						if (showcaseconfig.supplied) {
-							for (var n = 0; n < showcaseconfig.numberofrequests; n++) {
-								var requestdata;
-								if (showcaseconfig.itemarray[n] != undefined) {
-									num_of_requests++;
-									requestdata = {
-										appid: showcaseconfig.itemarray[n]["appid"],
-										item_contextid: showcaseconfig.itemarray[n]["item_contextid"],
-										item_assetid: showcaseconfig.itemarray[n]["item_assetid"],
-										customization_type: showcaseconfig.showcasetype,
-										slot: n,
-										sessionid: values.sessionID
-									};
+								case 'ownguides':
+									values["profile_showcase[12]"] = 12;
 
-									setTimeout(self._myProfile.bind(self, "ajaxsetshowcaseconfig", requestdata, function (err, response, body) {
+									if (settings[i][type].hasOwnProperty("values")) {
+										for (var n = 0; n < 5; n++) {
+											if (settings[i][type]["values"][n] != undefined) {
+												values["rgShowcaseConfig[12][" + n + "][appid]"] = settings[i][type]["values"][n]["appid"];
+												values["rgShowcaseConfig[12][" + n + "][publishedfileid]"] = settings[i][type]["values"][n]["publishedfileid"];
+											}
+										}
+									}
+									break;
+							}
 
-										if ((err || response.statusCode != 200) && this.showerrors) {
-											if (err) {
-												err.message += " | Happened while updating specific showcase items.";
+							if (showcaseconfig["supplied"]) {
+								for (var n = 0; n < showcaseconfig["numberofrequests"]; n++) {
+									var requestdata;
+									if (showcaseconfig["itemarray"][n] != undefined) {
+										numofrequests++;
+										requestdata = {
+											appid: showcaseconfig["itemarray"][n]["appid"],
+											item_contextid: showcaseconfig["itemarray"][n]["item_contextid"],
+											item_assetid: showcaseconfig["itemarray"][n]["item_assetid"],
+											customization_type: showcaseconfig["showcasetype"],
+											slot: n,
+											sessionid: values.sessionID
+										};
+
+										setTimeout(self._myProfile.bind(self, "ajaxsetshowcaseconfig", requestdata, function (err, response, body) {
+
+											if ((err || response.statusCode != 200) && this.showerrors) {
+												if (err) {
+													err.message += " | Happened while updating specific showcase items.";
+												}
+
+												if (callback && !this.error) {
+													callback(err || new Error("HTTP error " + response.statusCode + " | Happened while updating specific showcase items."));
+												}
+												this.error = true;
+												return;
 											}
 
-											if (callback && !this.error) {
-												callback(err || new Error("HTTP error " + response.statusCode + " | Happened while updating specific showcase items."));
-											}
-											this.error = true;
-											return;
-										}
 
-
-									}.bind(errorcontrol)), num_of_requests * 1500);
+										}.bind(errorcontrol)), numofrequests * 1500);
+									}
 								}
 							}
 						}
-
 					}
 					break;
 

--- a/components/profile.js
+++ b/components/profile.js
@@ -55,6 +55,9 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 		}
 
 		var formd = form.serializeArray();
+		if (formd[15].name != "profile_background") {
+			formd.splice(15, 0, {"name": "profile_background",	"value": ""});
+		}
 		var out = [].concat(formd.slice(0,19));
 
 		for(var i in settings) {

--- a/components/profile.js
+++ b/components/profile.js
@@ -58,7 +58,7 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 			values[item.name] = item.value;
 		});
 
-		var maxshowcases = $(".profile_showcase_selector").length;
+		var remainingshowcases = $(".profile_showcase_selector").length;
 
 		for (var i in settings) {
 			if (!settings.hasOwnProperty(i)) {
@@ -126,255 +126,256 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 
 					for (var type in settings[i]) {
 
-						if(maxshowcases > 0){
+						if (remainingshowcases === 0) {
+							break;
+						}
 
-							maxshowcases--;
+						remainingshowcases--;
 
-							//Variable used to easily make request to`ajaxsetshowcaseconfig` for showcases like trade, items, ...
-							var showcaseconfig = {
-								"supplied": false,
-								"numberofrequests": 0,
-								"showcasetype": 0,
-								"itemarray": []
-							};
+						//Variable used to easily make request to`ajaxsetshowcaseconfig` for showcases like trade, items, ...
+						var showcaseconfig = {
+							"supplied": false,
+							"numberofrequests": 0,
+							"showcasetype": 0,
+							"itemarray": []
+						};
 
-							//Controls if the callback function is called when a request changing f.e. a single item or game in a showcase fails
-							var errorcontrol = {
-								"error": false,
-								"showerrors": false
-							};
+						//Controls if the callback function is called when a request changing f.e. a single item or game in a showcase fails
+						var errorcontrol = {
+							"error": false,
+							"showerrors": false
+						};
 
-							if (settings[i][type].hasOwnProperty("values")) {
-								if (settings[i][type]["values"].hasOwnProperty("showshowcaseconfigerrors")) {
-									errorcontrol["showerrors"] = settings[i][type]["values"]["showshowcaseconfigerrors"];
-								}
+						if (settings[i][type].hasOwnProperty("values")) {
+							if (settings[i][type]["values"].hasOwnProperty("showshowcaseconfigerrors")) {
+								errorcontrol["showerrors"] = settings[i][type]["values"]["showshowcaseconfigerrors"];
 							}
+						}
 
-							switch (settings[i][type].showcase) {
+						switch (settings[i][type].showcase) {
 
-								case 'infobox':
-									values["profile_showcase[8]"] = 8;
+							case 'infobox':
+								values["profile_showcase[8]"] = 8;
 
-									if (settings[i][type].hasOwnProperty("values")){
-										if (settings[i][type]["values"].hasOwnProperty("title")){
-											values["rgShowcaseConfig[8][0][title]"] = settings[i][type]["values"]["title"];
-										}
-										if (settings[i][type]["values"].hasOwnProperty("notes")) {
-											values["rgShowcaseConfig[8][0][notes]"] = settings[i][type]["values"]["notes"];
-										}
+								if (settings[i][type].hasOwnProperty("values")) {
+									if (settings[i][type]["values"].hasOwnProperty("title")) {
+										values["rgShowcaseConfig[8][0][title]"] = settings[i][type]["values"]["title"];
+									}
+									if (settings[i][type]["values"].hasOwnProperty("notes")) {
+										values["rgShowcaseConfig[8][0][notes]"] = settings[i][type]["values"]["notes"];
+									}
+								}
+
+								break;
+
+							case 'artwork':
+								values["profile_showcase[13]"] = 13;
+
+								if (settings[i][type].hasOwnProperty("values")) {
+									for (var n = 0; n < 4; n++) {
+										values["profile_showcase[13][" + n + "][publishedfileid]"] = settings[i][type]["values"][n] || "";
+									}
+								}
+								break;
+
+							case 'trade':
+								values["profile_showcase[4]"] = 4;
+
+								if (settings[i][type].hasOwnProperty("values")) {
+
+									if (settings[i][type]["values"].hasOwnProperty("notes")) {
+										values["rgShowcaseConfig[4][6][notes]"] = settings[i][type]["values"]["notes"];
 									}
 
-									break;
-
-								case 'artwork':
-									values["profile_showcase[13]"] = 13;
-
-									if (settings[i][type].hasOwnProperty("values")) {
-										for (var n = 0; n < 4; n++) {
-											values["profile_showcase[13][" + n + "][publishedfileid]"] = settings[i][type]["values"][n] || "";
-										}
-									}
-									break;
-
-								case 'trade':
-									values["profile_showcase[4]"] = 4;
-
-									if (settings[i][type].hasOwnProperty("values")) {
-
-										if (settings[i][type]["values"].hasOwnProperty("notes")) {
-											values["rgShowcaseConfig[4][6][notes]"] = settings[i][type]["values"]["notes"];
-										}
-
-										if (settings[i][type]["values"].hasOwnProperty("items")) {
-											showcaseconfig["supplied"] = true;
-											showcaseconfig["numberofrequests"] = 6;
-											showcaseconfig["showcasetype"] = 4;
-											showcaseconfig["itemarray"] = settings[i][type]["values"]["items"];
-										}
-									}
-									break;
-
-								case 'items':
-									values["profile_showcase[3]"] = 3;
-
-									if (settings[i][type].hasOwnProperty("values") && settings[i][type]["values"].hasOwnProperty("items")) {
+									if (settings[i][type]["values"].hasOwnProperty("items")) {
 										showcaseconfig["supplied"] = true;
-										showcaseconfig["numberofrequests"] = 10;
-										showcaseconfig["showcasetype"] = 3;
+										showcaseconfig["numberofrequests"] = 6;
+										showcaseconfig["showcasetype"] = 4;
 										showcaseconfig["itemarray"] = settings[i][type]["values"]["items"];
 									}
-									break;
+								}
+								break;
 
-								case 'game':
-									values["profile_showcase[6]"] = 6;
+							case 'items':
+								values["profile_showcase[3]"] = 3;
 
-									if (settings[i][type].hasOwnProperty("values")) {
-										values["rgShowcaseConfig[6][0][appid]"] = settings[i][type]["values"];
+								if (settings[i][type].hasOwnProperty("values") && settings[i][type]["values"].hasOwnProperty("items")) {
+									showcaseconfig["supplied"] = true;
+									showcaseconfig["numberofrequests"] = 10;
+									showcaseconfig["showcasetype"] = 3;
+									showcaseconfig["itemarray"] = settings[i][type]["values"]["items"];
+								}
+								break;
+
+							case 'game':
+								values["profile_showcase[6]"] = 6;
+
+								if (settings[i][type].hasOwnProperty("values")) {
+									values["rgShowcaseConfig[6][0][appid]"] = settings[i][type]["values"];
+								}
+								break;
+
+							case 'badge':
+								values["profile_showcase[5]"] = 5;
+
+								if (settings[i][type].hasOwnProperty("values")) {
+
+									if (settings[i][type]["values"].hasOwnProperty("style")) {
+										var styles = ["rare", "selected", null, "recent", "random"];
+										values["profile_showcase_style_5"] = styles.indexOf(settings[i][type]["values"]["style"]);
 									}
-									break;
 
-								case 'badge':
-									values["profile_showcase[5]"] = 5;
-
-									if (settings[i][type].hasOwnProperty("values")) {
-
-										if (settings[i][type]["values"].hasOwnProperty("style")) {
-											var styles = ["rare", "selected", null, "recent", "random"];
-											values["profile_showcase_style_5"] = styles.indexOf(settings[i][type]["values"]["style"]);
-										}
-
-										if (settings[i][type]["values"].hasOwnProperty("badges")) {
-											var types = ["badgeid", "appid", "border_color"];
-											for (var n = 0; n < 6; n++) {
-												for (var t in type){
-													if (settings[i][type]["values"]["badges"][n] != undefined) {
-														if (settings[i][type]["values"]["badges"][n].hasOwnProperty(types[t])){
-															values["rgShowcaseConfig[5][" + n + "][" + types[t] + "]"] = settings[i][type]["values"]["badges"][n][types[t]] || values["rgShowcaseConfig[5][" + n + "][" + types[t] + "]"] || "";
-														}
+									if (settings[i][type]["values"].hasOwnProperty("badges")) {
+										var types = ["badgeid", "appid", "border_color"];
+										for (var n = 0; n < 6; n++) {
+											for (var t in type) {
+												if (settings[i][type]["values"]["badges"][n] != undefined) {
+													if (settings[i][type]["values"]["badges"][n].hasOwnProperty(types[t])) {
+														values["rgShowcaseConfig[5][" + n + "][" + types[t] + "]"] = settings[i][type]["values"]["badges"][n][types[t]] || values["rgShowcaseConfig[5][" + n + "][" + types[t] + "]"] || "";
 													}
 												}
 											}
 										}
 									}
+								}
 
-									break;
+								break;
 
-								case 'rareachievements':
-									values["profile_showcase[1]"] = 1;
-									break;
+							case 'rareachievements':
+								values["profile_showcase[1]"] = 1;
+								break;
 
-								case 'screenshot':
-									values["profile_showcase[7]"] = 7;
+							case 'screenshot':
+								values["profile_showcase[7]"] = 7;
 
-									if (settings[i][type].hasOwnProperty("values")) {
-										for (var n = 0; n < 4; n++) {
-											if (settings[i][type]["values"][n] != undefined) {
-												values["rgShowcaseConfig[7][" + n + "][publishedfileid]"] = settings[i][type]["values"][n];
-											}
+								if (settings[i][type].hasOwnProperty("values")) {
+									for (var n = 0; n < 4; n++) {
+										if (settings[i][type]["values"][n] != undefined) {
+											values["rgShowcaseConfig[7][" + n + "][publishedfileid]"] = settings[i][type]["values"][n];
 										}
 									}
-									break;
+								}
+								break;
 
-								case 'group':
-									values["profile_showcase[9]"] = 9;
+							case 'group':
+								values["profile_showcase[9]"] = 9;
 
-									if (settings[i][type].hasOwnProperty("values")) {
-										if (typeof settings[i][type]["values"] === 'object' && settings[i][type]["values"].getSteamID64) {
-											values["rgShowcaseConfig[9][0][accountid]"] = settings[i][type]["values"].getSteamID64();
-										} else {
-											values["rgShowcaseConfig[9][0][accountid]"] = new SteamID(settings[i][type]["values"]).getSteamID64();
+								if (settings[i][type].hasOwnProperty("values")) {
+									if (typeof settings[i][type]["values"] === 'object' && settings[i][type]["values"].getSteamID64) {
+										values["rgShowcaseConfig[9][0][accountid]"] = settings[i][type]["values"].getSteamID64();
+									} else {
+										values["rgShowcaseConfig[9][0][accountid]"] = new SteamID(settings[i][type]["values"]).getSteamID64();
+									}
+								}
+								break;
+
+							case 'review':
+								values["profile_showcase[10]"] = 10;
+
+								if (settings[i][type].hasOwnProperty("values")) {
+									values["rgShowcaseConfig[10][0][appid]"] = settings[i][type]["values"];
+								}
+								break;
+
+							case 'workshop':
+								values["profile_showcase[11]"] = 11;
+
+								if (settings[i][type].hasOwnProperty("values")) {
+									values["rgShowcaseConfig[11][0][appid]"] = settings[i][type]["values"]["appid"];
+									values["rgShowcaseConfig[11][0][publishedfileid]"] = settings[i][type]["values"]["publishedfileid"];
+								}
+								break;
+
+							case 'guide':
+								values["profile_showcase[15]"] = 15;
+
+								if (settings[i][type].hasOwnProperty("values")) {
+									values["rgShowcaseConfig[15][0][appid]"] = settings[i][type]["values"]["appid"];
+									values["rgShowcaseConfig[15][0][publishedfileid]"] = settings[i][type]["values"]["publishedfileid"];
+								}
+								break;
+
+							case 'achievements':
+								values["profile_showcase[17]"] = 17;
+
+								if (settings[i][type].hasOwnProperty("values") && settings[i][type]["values"].hasOwnProperty("achievements")) {
+									for (var n = 0; n < 7; n++) {
+										if (settings[i][type]["values"]["achievements"][n] != undefined) {
+											values["rgShowcaseConfig[17][" + n + "][appid]"] = settings[i][type]["values"]["achievements"][n]["appid"];
+											values["rgShowcaseConfig[17][" + n + "][title]"] = settings[i][type]["values"]["achievements"][n]["title"];
 										}
 									}
-									break;
+								}
+								break;
 
-								case 'review':
-									values["profile_showcase[10]"] = 10;
+							case 'games':
+								values["profile_showcase[2]"] = 2;
 
-									if (settings[i][type].hasOwnProperty("values")) {
-										values["rgShowcaseConfig[10][0][appid]"] = settings[i][type]["values"];
-									}
-									break;
+								if (settings[i][type].hasOwnProperty("values") && settings[i][type]["values"].hasOwnProperty("games")) {
+									showcaseconfig["supplied"] = true;
+									showcaseconfig["numberofrequests"] = 4;
+									showcaseconfig["showcasetype"] = 2;
+									showcaseconfig["itemarray"] = settings[i][type]["values"]["games"];
+								}
+								break;
 
-								case 'workshop':
-									values["profile_showcase[11]"] = 11;
+							case 'ownguides':
+								values["profile_showcase[16]"] = 16;
 
-									if (settings[i][type].hasOwnProperty("values")) {
-										values["rgShowcaseConfig[11][0][appid]"] = settings[i][type]["values"]["appid"];
-										values["rgShowcaseConfig[11][0][publishedfileid]"] = settings[i][type]["values"]["publishedfileid"];
-									}
-									break;
-
-								case 'guide':
-									values["profile_showcase[15]"] = 15;
-
-									if (settings[i][type].hasOwnProperty("values")) {
-										values["rgShowcaseConfig[15][0][appid]"] = settings[i][type]["values"]["appid"];
-										values["rgShowcaseConfig[15][0][publishedfileid]"] = settings[i][type]["values"]["publishedfileid"];
-									}
-									break;
-
-								case 'achievements':
-									values["profile_showcase[17]"] = 17;
-
-									if (settings[i][type].hasOwnProperty("values") && settings[i][type]["values"].hasOwnProperty("achievements")) {
-										for (var n = 0; n < 7; n++) {
-											if (settings[i][type]["values"]["achievements"][n] != undefined) {
-												values["rgShowcaseConfig[17][" + n + "][appid]"] = settings[i][type]["values"]["achievements"][n]["appid"];
-												values["rgShowcaseConfig[17][" + n + "][title]"] = settings[i][type]["values"]["achievements"][n]["title"];
-											}
+								if (settings[i][type].hasOwnProperty("values")) {
+									for (var n = 0; n < 4; n++) {
+										if (settings[i][type]["values"][n] != undefined) {
+											values["rgShowcaseConfig[16][" + n + "][appid]"] = settings[i][type]["values"][n]["appid"];
+											values["rgShowcaseConfig[16][" + n + "][publishedfileid]"] = settings[i][type]["values"][n]["publishedfileid"];
 										}
 									}
-									break;
+								}
+								break;
 
-								case 'games':
-									values["profile_showcase[2]"] = 2;
+							case 'ownworkshop':
+								values["profile_showcase[12]"] = 12;
 
-									if (settings[i][type].hasOwnProperty("values") && settings[i][type]["values"].hasOwnProperty("games")) {
-										showcaseconfig["supplied"] = true;
-										showcaseconfig["numberofrequests"] = 4;
-										showcaseconfig["showcasetype"] = 2;
-										showcaseconfig["itemarray"] = settings[i][type]["values"]["games"];
-									}
-									break;
-
-								case 'ownguides':
-									values["profile_showcase[16]"] = 16;
-
-									if (settings[i][type].hasOwnProperty("values")) {
-										for (var n = 0; n < 4; n++) {
-											if (settings[i][type]["values"][n] != undefined) {
-												values["rgShowcaseConfig[16][" + n + "][appid]"] = settings[i][type]["values"][n]["appid"];
-												values["rgShowcaseConfig[16][" + n + "][publishedfileid]"] = settings[i][type]["values"][n]["publishedfileid"];
-											}
+								if (settings[i][type].hasOwnProperty("values")) {
+									for (var n = 0; n < 5; n++) {
+										if (settings[i][type]["values"][n] != undefined) {
+											values["rgShowcaseConfig[12][" + n + "][appid]"] = settings[i][type]["values"][n]["appid"];
+											values["rgShowcaseConfig[12][" + n + "][publishedfileid]"] = settings[i][type]["values"][n]["publishedfileid"];
 										}
 									}
-									break;
+								}
+								break;
+						}
 
-								case 'ownworkshop':
-									values["profile_showcase[12]"] = 12;
+						if (showcaseconfig["supplied"]) {
+							for (var n = 0; n < showcaseconfig["numberofrequests"]; n++) {
+								var requestdata;
+								if (showcaseconfig["itemarray"][n] != undefined) {
+									numofrequests++;
+									requestdata = {
+										appid: showcaseconfig["itemarray"][n]["appid"],
+										item_contextid: showcaseconfig["itemarray"][n]["item_contextid"],
+										item_assetid: showcaseconfig["itemarray"][n]["item_assetid"],
+										customization_type: showcaseconfig["showcasetype"],
+										slot: n,
+										sessionid: values.sessionID
+									};
 
-									if (settings[i][type].hasOwnProperty("values")) {
-										for (var n = 0; n < 5; n++) {
-											if (settings[i][type]["values"][n] != undefined) {
-												values["rgShowcaseConfig[12][" + n + "][appid]"] = settings[i][type]["values"][n]["appid"];
-												values["rgShowcaseConfig[12][" + n + "][publishedfileid]"] = settings[i][type]["values"][n]["publishedfileid"];
+									setTimeout(self._myProfile.bind(self, "ajaxsetshowcaseconfig", requestdata, function (err, response, body) {
+
+										if ((err || response.statusCode != 200) && this.showerrors) {
+											if (err) {
+												err.message += " | Happened while updating specific showcase items.";
 											}
+
+											if (callback && !this.error) {
+												callback(err || new Error("HTTP error " + response.statusCode + " | Happened while updating specific showcase items."));
+											}
+											this.error = true;
+											return;
 										}
-									}
-									break;
-							}
-
-							if (showcaseconfig["supplied"]) {
-								for (var n = 0; n < showcaseconfig["numberofrequests"]; n++) {
-									var requestdata;
-									if (showcaseconfig["itemarray"][n] != undefined) {
-										numofrequests++;
-										requestdata = {
-											appid: showcaseconfig["itemarray"][n]["appid"],
-											item_contextid: showcaseconfig["itemarray"][n]["item_contextid"],
-											item_assetid: showcaseconfig["itemarray"][n]["item_assetid"],
-											customization_type: showcaseconfig["showcasetype"],
-											slot: n,
-											sessionid: values.sessionID
-										};
-
-										setTimeout(self._myProfile.bind(self, "ajaxsetshowcaseconfig", requestdata, function (err, response, body) {
-
-											if ((err || response.statusCode != 200) && this.showerrors) {
-												if (err) {
-													err.message += " | Happened while updating specific showcase items.";
-												}
-
-												if (callback && !this.error) {
-													callback(err || new Error("HTTP error " + response.statusCode + " | Happened while updating specific showcase items."));
-												}
-												this.error = true;
-												return;
-											}
 
 
-										}.bind(errorcontrol)), numofrequests * 1500);
-									}
+									}.bind(errorcontrol)), numofrequests * 1500);
 								}
 							}
 						}

--- a/components/profile.js
+++ b/components/profile.js
@@ -33,7 +33,6 @@ SteamCommunity.prototype.setupProfile = function(callback) {
 };
 
 SteamCommunity.prototype.editShowcaseItem = function(showcase, slot, item, callback) {
-	const self = this;
 	//The possible options, with the maximum number of slots and the corresponding type
 	const allowedoptions = {
 		"trade": {
@@ -50,23 +49,23 @@ SteamCommunity.prototype.editShowcaseItem = function(showcase, slot, item, callb
 		}
 	};
 
-	if(!allowedoptions.hasOwnProperty(showcase)){
+	if (!allowedoptions.hasOwnProperty(showcase)) {
 		const err = new Error("The submitted showcase type has no editable items.");
 		return callback ? callback(err) : undefined;
 	}
-	if(slot < 1 || slot > allowedoptions[showcase]["maxslots"]){
+	if (slot < 1 || slot > allowedoptions[showcase]["maxslots"]) {
 		const err = new Error("The submitted slot is outside of range. (Allowed range: 1-"+allowedoptions[showcase]["maxslots"]+")");
 		return callback ? callback(err) : undefined;
 	}
-	if(!(item.hasOwnProperty("appid") || item.hasOwnProperty("item_contextid") || item.hasOwnProperty("item_assetid"))){
+	if (!(item.hasOwnProperty("appid") || item.hasOwnProperty("item_contextid") || item.hasOwnProperty("item_assetid"))) {
 		const err = new Error("The submitted item is not valid.");
 		return callback ? callback(err) : undefined;
 	}
-	const requestdata = item;
+	const requestdata = Object.assign({}, item);
 	requestdata["slot"] = slot - 1;
 	requestdata["customization_type"] = allowedoptions[showcase]["type"];
-	requestdata["sessionid"] = self.getSessionID();
-	self._myProfile("ajaxsetshowcaseconfig", requestdata, function (err, response, body) {
+	requestdata["sessionid"] = this.getSessionID();
+	this._myProfile("ajaxsetshowcaseconfig", requestdata, function (err, response, body) {
 
 		if (err || response.statusCode != 200) {
 			err = err || new Error("HTTP error " + response.statusCode);

--- a/components/profile.js
+++ b/components/profile.js
@@ -132,7 +132,13 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 
 				case 'showcases':
 					for (var t in settings[i]) {
-						var showcaseconfig = [false,0,0,[]];
+						//Variable used to easily make request to`ajaxsetshowcaseconfig` for showcases like trade, items, ...
+						var showcaseconfig = {
+							"supplied": false,
+							"numberofrequests": 0,
+							"showcasetype": 0,
+							"itemarray": []
+						};
 
 						switch (settings[i][t].showcase) {
 
@@ -175,7 +181,10 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 								});
 
 								if (settings[i][t]["values"].hasOwnProperty("items")) {
-									showcaseconfig = [true, 6, 4, settings[i][t]["values"]["items"]];
+									showcaseconfig.supplied = true;
+									showcaseconfig.numberofrequests = 6;
+									showcaseconfig.showcasetype = 4;
+									showcaseconfig.itemarray = settings[i][t]["values"]["items"];
 								}
 								break;
 
@@ -186,7 +195,10 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 								});
 
 								if (settings[i][t]["values"].hasOwnProperty("items")) {
-									showcaseconfig = [true, 10, 3, settings[i][t]["values"]["items"]];
+									showcaseconfig.supplied = true;
+									showcaseconfig.numberofrequests = 10;
+									showcaseconfig.showcasetype = 3;
+									showcaseconfig.itemarray = settings[i][t]["values"]["items"];
 								}
 								break;
 
@@ -344,7 +356,10 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 									});
 
 									if (settings[i][t]["values"].hasOwnProperty("games")) {
-										showcaseconfig = [true, 4, 2, settings[i][t]["values"]["games"]];
+										showcaseconfig.supplied = true;
+										showcaseconfig.numberofrequests = 4;
+										showcaseconfig.showcasetype = 2;
+										showcaseconfig.itemarray = settings[i][t]["values"]["games"];
 									}
 									break;
 
@@ -393,24 +408,24 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 									break;
 							}
 
-							if (showcaseconfig[0]) {
-								for (var n = 0; n < showcaseconfig[1]; n++) {
+							if (showcaseconfig.supplied) {
+								for (var n = 0; n < showcaseconfig.numberofrequests; n++) {
 									var requestdata;
-									if (showcaseconfig[3][n] == undefined) {
+									if (showcaseconfig.itemarray[n] == undefined) {
 										requestdata = {
 											appid: 0,
 											item_contextid: 0,
 											item_assetid: 0,
-											customization_type: showcaseconfig[2],
+											customization_type: showcaseconfig.showcasetype,
 											slot: n,
 											sessionid: formd[0].value
 										};
 									} else {
 										requestdata = {
-											appid: showcaseconfig[3][n]["appid"],
-											item_contextid: showcaseconfig[3][n]["item_contextid"],
-											item_assetid: showcaseconfig[3][n]["item_assetid"],
-											customization_type: showcaseconfig[2],
+											appid: showcaseconfig.itemarray[n]["appid"],
+											item_contextid: showcaseconfig.itemarray[n]["item_contextid"],
+											item_assetid: showcaseconfig.itemarray[n]["item_assetid"],
+											customization_type: showcaseconfig.showcasetype,
 											slot: n,
 											sessionid: formd[0].value
 										};

--- a/components/profile.js
+++ b/components/profile.js
@@ -64,408 +64,408 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 
 			switch(i) {
 				case 'name':
-          out[8] = {
-            "name": formd[8].name,
-            "value": settings[i]
-          };
-	        break;
+					out[8] = {
+						"name": formd[8].name,
+						"value": settings[i]
+					};
+					break;
 
-        case 'realName':
-          out[9] = {
-            "name": formd[9].name,
-            "value": settings[i]
-          };
-          break;
+				case 'realName':
+					out[9] = {
+						"name": formd[9].name,
+						"value": settings[i]
+					};
+					break;
 
-        case 'summary':
-	        out[14] = {
-	          "name": formd[14].name,
-	          "value": settings[i]
-	        };
-          break;
+				case 'summary':
+					out[14] = {
+						"name": formd[14].name,
+						"value": settings[i]
+					};
+					break;
 
-        case 'country':
-          out[10] = {
-            "name": formd[10].name,
-            "value": settings[i]
-          };
-          break;
+				case 'country':
+					out[10] = {
+						"name": formd[10].name,
+						"value": settings[i]
+					};
+					break;
 
-        case 'state':
-          out[11] = {
-            "name": formd[11].name,
-            "value": settings[i]
-          };
-          break;
+				case 'state':
+					out[11] = {
+						"name": formd[11].name,
+						"value": settings[i]
+					};
+					break;
 
-        case 'city':
-          out[12] = {
-            "name": formd[12].name,
-            "value": settings[i]
-          };
-          break;
+				case 'city':
+					out[12] = {
+						"name": formd[12].name,
+						"value": settings[i]
+					};
+					break;
 
-        case 'customURL':
-          out[13] = {
-            "name": formd[13].name,
-            "value": settings[i]
-          };
-          break;
+				case 'customURL':
+					out[13] = {
+						"name": formd[13].name,
+						"value": settings[i]
+					};
+					break;
 
-        case 'background':
-          // The assetid of our desired profile background
-          out[15] = {
-            "name": formd[15].name,
-            "value": settings[i]
-          };
-          break;
+				case 'background':
+					// The assetid of our desired profile background
+					out[15] = {
+						"name": formd[15].name,
+						"value": settings[i]
+					};
+					break;
 
-        case 'featuredBadge':
-          // Currently, game badges aren't supported
-            out[16] = {
-              "name": formd[16].name,
-              "value": settings[i]
-            };
-          break;
+				case 'featuredBadge':
+					// Currently, game badges aren't supported
+						out[16] = {
+							"name": formd[16].name,
+							"value": settings[i]
+						};
+					break;
 
-        case 'primaryGroup':
-          if (typeof settings[i] === 'object' && settings[i].getSteamID64) {
-            out[18] = {
-              "name": formd[18].name,
-              "value": settings[i].getSteamID64()
-            };
-          } else {
-            out[18] = {
-              "name": formd[18].name,
-              "value": new SteamID(settings[i]).getSteamID64()
-            };
-          }
+				case 'primaryGroup':
+					if (typeof settings[i] === 'object' && settings[i].getSteamID64) {
+						out[18] = {
+							"name": formd[18].name,
+							"value": settings[i].getSteamID64()
+						};
+					} else {
+						out[18] = {
+							"name": formd[18].name,
+							"value": new SteamID(settings[i]).getSteamID64()
+						};
+					}
 
-          break;
+					break;
 
-        case 'showcases':
-          for (var t in settings[i]) {
-            var showcaseconfig = [false,0,0,[]];
+				case 'showcases':
+					for (var t in settings[i]) {
+						var showcaseconfig = [false,0,0,[]];
 
-            switch (settings[i][t].showcase) {
+						switch (settings[i][t].showcase) {
 
-              case 'infobox':
-                out.push({
-                  "name": "profile_showcase[]",
-                  "value": "8"
-                });
-                out.push({
-                  "name": "rgShowcaseConfig[8][0][title]",
-                  "value": settings[i][t]["values"]["title"]
-                });
-                out.push({
-                  "name": "rgShowcaseConfig[8][0][notes]",
-                  "value": settings[i][t]["values"]["notes"]
-                });
-                break;
+							case 'infobox':
+								out.push({
+									"name": "profile_showcase[]",
+									"value": "8"
+								});
+								out.push({
+									"name": "rgShowcaseConfig[8][0][title]",
+									"value": settings[i][t]["values"]["title"]
+								});
+								out.push({
+									"name": "rgShowcaseConfig[8][0][notes]",
+									"value": settings[i][t]["values"]["notes"]
+								});
+								break;
 
-              case 'artwork':
-                out.push({
-                  "name": "profile_showcase[]",
-                  "value": "13"
-                });
-                for (var n = 0; n < 4; n++) {
-                  out.push({
-                    "name": "rgShowcaseConfig[13][" + n + "][publishedfileid]",
-                    "value": settings[i][t]["values"][n] || ""
-                  });
-                }
-                break;
+							case 'artwork':
+								out.push({
+									"name": "profile_showcase[]",
+									"value": "13"
+								});
+								for (var n = 0; n < 4; n++) {
+									out.push({
+										"name": "rgShowcaseConfig[13][" + n + "][publishedfileid]",
+										"value": settings[i][t]["values"][n] || ""
+									});
+								}
+								break;
 
-              case 'trade':
-                out.push({
-                  "name": "profile_showcase[]",
-                  "value": "4"
-                });
-                out.push({
-                  "name": "rgShowcaseConfig[4][6][notes]",
-                  "value": settings[i][t]["values"]["notes"]
-                });
+							case 'trade':
+								out.push({
+									"name": "profile_showcase[]",
+									"value": "4"
+								});
+								out.push({
+									"name": "rgShowcaseConfig[4][6][notes]",
+									"value": settings[i][t]["values"]["notes"]
+								});
 
-                if (settings[i][t]["values"].hasOwnProperty("items")) {
-                  showcaseconfig = [true, 6, 4, settings[i][t]["values"]["items"]];
-                }
-                break;
+								if (settings[i][t]["values"].hasOwnProperty("items")) {
+									showcaseconfig = [true, 6, 4, settings[i][t]["values"]["items"]];
+								}
+								break;
 
-              case 'items':
-                out.push({
-                  "name": "profile_showcase[]",
-                  "value": "3"
-                });
+							case 'items':
+								out.push({
+									"name": "profile_showcase[]",
+									"value": "3"
+								});
 
-                if (settings[i][t]["values"].hasOwnProperty("items")) {
-                  showcaseconfig = [true, 10, 3, settings[i][t]["values"]["items"]];
-                }
-                break;
+								if (settings[i][t]["values"].hasOwnProperty("items")) {
+									showcaseconfig = [true, 10, 3, settings[i][t]["values"]["items"]];
+								}
+								break;
 
-              case 'game':
-                out.push({
-                  "name": "profile_showcase[]",
-                  "value": "6"
-                });
-                out.push({
-                  "name": "rgShowcaseConfig[6][0][appid]",
-                  "value": settings[i][t]["values"]["appid"]
-                });
-                break;
+							case 'game':
+								out.push({
+									"name": "profile_showcase[]",
+									"value": "6"
+								});
+								out.push({
+									"name": "rgShowcaseConfig[6][0][appid]",
+									"value": settings[i][t]["values"]["appid"]
+								});
+								break;
 
-              case 'badge':
-                out.push({
-                  "name": "profile_showcase[]",
-                  "value": "5"
-                });
-                var styles = ["rare","selected",null,"recent","random"];
-                out.push({
-                  "name": "profile_showcase_style_5",
-                  "value": styles.indexOf(settings[i][t]["values"]["style"])
-                });
+							case 'badge':
+								out.push({
+									"name": "profile_showcase[]",
+									"value": "5"
+								});
+								var styles = ["rare","selected",null,"recent","random"];
+								out.push({
+									"name": "profile_showcase_style_5",
+									"value": styles.indexOf(settings[i][t]["values"]["style"])
+								});
 
-                if (settings[i][t]["values"].hasOwnProperty("badges")){
-                  for(var n = 0; n < 6; n++){
+								if (settings[i][t]["values"].hasOwnProperty("badges")){
+									for(var n = 0; n < 6; n++){
 										var defaultval = ["", "", ""];
-		                if (settings[i][t]["values"]["badges"][n] != undefined) {
-		                  defaultval = [settings[i][t]["values"]["badges"][n]["badgeid"], settings[i][t]["values"]["badges"][n]["appid"], settings[i][t]["values"]["badges"][n]["border_color"]];
-		                }
-		                out.push({
-		                  "name": "rgShowcaseConfig[5][" + n + "][badgeid]",
-		                  "value": defaultval[0]
-		                });
-		                out.push({
-		                  "name": "rgShowcaseConfig[5][" + n + "][appid]",
-		                  "value": defaultval[1]
-		                });
-		                out.push({
-		                  "name": "rgShowcaseConfig[5][" + n + "][border_color]",
-		                  "value": defaultval[2]
-		                });
-                  }
-                }
+										if (settings[i][t]["values"]["badges"][n] != undefined) {
+											defaultval = [settings[i][t]["values"]["badges"][n]["badgeid"], settings[i][t]["values"]["badges"][n]["appid"], settings[i][t]["values"]["badges"][n]["border_color"]];
+										}
+										out.push({
+											"name": "rgShowcaseConfig[5][" + n + "][badgeid]",
+											"value": defaultval[0]
+										});
+										out.push({
+											"name": "rgShowcaseConfig[5][" + n + "][appid]",
+											"value": defaultval[1]
+										});
+										out.push({
+											"name": "rgShowcaseConfig[5][" + n + "][border_color]",
+											"value": defaultval[2]
+										});
+									}
+								}
 
-                break;
+								break;
 
-              case 'rareachievements':
-                out.push({
-                  "name": "profile_showcase[]",
-                  "value": "1"
-                });
-                break;
+							case 'rareachievements':
+								out.push({
+									"name": "profile_showcase[]",
+									"value": "1"
+								});
+								break;
 
-              case 'screenshot':
-                out.push({
-                  "name": "profile_showcase[]",
-                  "value": "7"
-                });
-                for (var n = 0; n < 4; n++) {
-                  out.push({
-                    "name": "rgShowcaseConfig[7][" + n + "][publishedfileid]",
-                    "value": settings[i][t]["values"][n] || ""
-                  });
-                }
-                break;
+							case 'screenshot':
+								out.push({
+									"name": "profile_showcase[]",
+									"value": "7"
+								});
+								for (var n = 0; n < 4; n++) {
+									out.push({
+										"name": "rgShowcaseConfig[7][" + n + "][publishedfileid]",
+										"value": settings[i][t]["values"][n] || ""
+									});
+								}
+								break;
 
-              case 'group':
-                out.push({
-                  "name": "profile_showcase[]",
-                  "value": "9"
-                });
-                if (typeof settings[i][t]["values"]["groupid"] === 'object' && settings[i][t]["values"]["groupid"].getSteamID64) {
-                  out.push({
-                    "name": "rgShowcaseConfig[9][0][accountid]",
-                    "value": settings[i][t]["values"]["groupid"].getSteamID64()
-                  });
-                } else {
-                  out.push({
-                    "name": "rgShowcaseConfig[9][0][accountid]",
-                    "value": new SteamID(settings[i][t]["values"]["groupid"]).getSteamID64()
-                  });
-                }
-                break;
+							case 'group':
+								out.push({
+									"name": "profile_showcase[]",
+									"value": "9"
+								});
+								if (typeof settings[i][t]["values"]["groupid"] === 'object' && settings[i][t]["values"]["groupid"].getSteamID64) {
+									out.push({
+										"name": "rgShowcaseConfig[9][0][accountid]",
+										"value": settings[i][t]["values"]["groupid"].getSteamID64()
+									});
+								} else {
+									out.push({
+										"name": "rgShowcaseConfig[9][0][accountid]",
+										"value": new SteamID(settings[i][t]["values"]["groupid"]).getSteamID64()
+									});
+								}
+								break;
 
-              case 'review':
-                out.push({
-                  "name": "profile_showcase[]",
-                  "value": "10"
-                });
-                out.push({
-                  "name": "rgShowcaseConfig[10][0][appid]",
-                  "value": settings[i][t]["values"]["appid"]
-                });
-                break;
+							case 'review':
+								out.push({
+									"name": "profile_showcase[]",
+									"value": "10"
+								});
+								out.push({
+									"name": "rgShowcaseConfig[10][0][appid]",
+									"value": settings[i][t]["values"]["appid"]
+								});
+								break;
 
-              case 'workshop':
-                out.push({
-                  "name": "profile_showcase[]",
-                  "value": "11"
-                });
-                out.push({
-                  "name": "rgShowcaseConfig[11][0][appid]",
-                  "value": settings[i][t]["values"]["appid"]
-                });
-                out.push({
-                  "name": "rgShowcaseConfig[11][0][publishedfileid]",
-                  "value": settings[i][t]["values"]["publishedfileid"]
-                });
-                break;
+							case 'workshop':
+								out.push({
+									"name": "profile_showcase[]",
+									"value": "11"
+								});
+								out.push({
+									"name": "rgShowcaseConfig[11][0][appid]",
+									"value": settings[i][t]["values"]["appid"]
+								});
+								out.push({
+									"name": "rgShowcaseConfig[11][0][publishedfileid]",
+									"value": settings[i][t]["values"]["publishedfileid"]
+								});
+								break;
 
-              case 'guide':
-                out.push({
-                  "name": "profile_showcase[]",
-                  "value": "15"
-                });
-                out.push({
-                  "name": "rgShowcaseConfig[15][0][appid]",
-                  "value": settings[i][t]["values"]["appid"]
-                });
-                out.push({
-                  "name": "rgShowcaseConfig[15][0][publishedfileid]",
-                  "value": settings[i][t]["values"]["publishedfileid"]
-                });
-                break;
+							case 'guide':
+								out.push({
+									"name": "profile_showcase[]",
+									"value": "15"
+								});
+								out.push({
+									"name": "rgShowcaseConfig[15][0][appid]",
+									"value": settings[i][t]["values"]["appid"]
+								});
+								out.push({
+									"name": "rgShowcaseConfig[15][0][publishedfileid]",
+									"value": settings[i][t]["values"]["publishedfileid"]
+								});
+								break;
 
-              case 'achievements':
-                out.push({
-                  "name": "profile_showcase[]",
-                  "value": "17"
-                });
-                if (settings[i][t]["values"].hasOwnProperty("achievements")) {
-                  for (var n = 0; n < 7; n++) {
+							case 'achievements':
+								out.push({
+									"name": "profile_showcase[]",
+									"value": "17"
+								});
+								if (settings[i][t]["values"].hasOwnProperty("achievements")) {
+									for (var n = 0; n < 7; n++) {
 										var defaultval = ["", ""];
-		                if (settings[i][t]["values"]["achievements"][n] != undefined) {
-		                  defaultval = [settings[i][t]["values"]["achievements"][n]["appid"], settings[i][t]["values"]["achievements"][n]["title"]];
-		                }
-		                out.push({
-		                  "name": "rgShowcaseConfig[17][" + n + "][appid]",
-		                  "value": defaultval[0]
-		                });
-		                out.push({
-		                  "name": "rgShowcaseConfig[17][" + n + "][title]",
-		                  "value": defaultval[1]
-		                });
-                  }
-                }
-              	break;
+										if (settings[i][t]["values"]["achievements"][n] != undefined) {
+											defaultval = [settings[i][t]["values"]["achievements"][n]["appid"], settings[i][t]["values"]["achievements"][n]["title"]];
+										}
+										out.push({
+											"name": "rgShowcaseConfig[17][" + n + "][appid]",
+											"value": defaultval[0]
+										});
+										out.push({
+											"name": "rgShowcaseConfig[17][" + n + "][title]",
+											"value": defaultval[1]
+										});
+									}
+								}
+								break;
 
 								case 'games':
-                  out.push({
-                    "name": "profile_showcase[]",
-                    "value": "2"
-                  });
+									out.push({
+										"name": "profile_showcase[]",
+										"value": "2"
+									});
 
-                  if (settings[i][t]["values"].hasOwnProperty("games")) {
-                    showcaseconfig = [true, 4, 2, settings[i][t]["values"]["games"]];
-                  }
-                  break;
+									if (settings[i][t]["values"].hasOwnProperty("games")) {
+										showcaseconfig = [true, 4, 2, settings[i][t]["values"]["games"]];
+									}
+									break;
 
-                case 'ownguides':
-                  out.push({
-                    "name": "profile_showcase[]",
-                    "value": "16"
-                  });
+								case 'ownguides':
+									out.push({
+										"name": "profile_showcase[]",
+										"value": "16"
+									});
 
-                  for (var n = 0; n < 4; n++) {
-                    var defaultval = ["", ""];
-		                if (settings[i][t]["values"][n] != undefined) {
-		                  defaultval = [settings[i][t]["values"][n]["appid"], settings[i][t]["values"][n]["publishedfileid"]];
-		                }
-                    out.push({
-                      "name": "rgShowcaseConfig[16][" + n + "][appid]",
-                      "value": defaultval[0]
-                    });
-                    out.push({
-                      "name": "rgShowcaseConfig[16][" + n + "][publishedfileid]",
-                      "value": defaultval[1]
-                    });
-                  }
-                  break;
+									for (var n = 0; n < 4; n++) {
+										var defaultval = ["", ""];
+										if (settings[i][t]["values"][n] != undefined) {
+											defaultval = [settings[i][t]["values"][n]["appid"], settings[i][t]["values"][n]["publishedfileid"]];
+										}
+										out.push({
+											"name": "rgShowcaseConfig[16][" + n + "][appid]",
+											"value": defaultval[0]
+										});
+										out.push({
+											"name": "rgShowcaseConfig[16][" + n + "][publishedfileid]",
+											"value": defaultval[1]
+										});
+									}
+									break;
 
-                case 'ownguides':
-                  out.push({
-                    "name": "profile_showcase[]",
-                    "value": "12"
-                  });
+								case 'ownguides':
+									out.push({
+										"name": "profile_showcase[]",
+										"value": "12"
+									});
 
-                  for (var n = 0; n < 5; n++) {
-                    var defaultval = ["", ""];
-                    if (settings[i][t]["values"][n] != undefined) {
-                      defaultval = [settings[i][t]["values"][n]["appid"], settings[i][t]["values"][n]["publishedfileid"]];
-                    }
-                    out.push({
-                      "name": "rgShowcaseConfig[12][" + n + "][appid]",
-                      "value": defaultval[0]
-                    });
-                    out.push({
-                      "name": "rgShowcaseConfig[12][" + n + "][publishedfileid]",
-                      "value": defaultval[1]
-                    });
-                  }
-                  break;
-              }
+									for (var n = 0; n < 5; n++) {
+										var defaultval = ["", ""];
+										if (settings[i][t]["values"][n] != undefined) {
+											defaultval = [settings[i][t]["values"][n]["appid"], settings[i][t]["values"][n]["publishedfileid"]];
+										}
+										out.push({
+											"name": "rgShowcaseConfig[12][" + n + "][appid]",
+											"value": defaultval[0]
+										});
+										out.push({
+											"name": "rgShowcaseConfig[12][" + n + "][publishedfileid]",
+											"value": defaultval[1]
+										});
+									}
+									break;
+							}
 
-              if (showcaseconfig[0]) {
-                for (var n = 0; n < showcaseconfig[1]; n++) {
-                  var requestdata;
-                  if (showcaseconfig[3][n] == undefined) {
-                    requestdata = {
-                      appid: 0,
-                      item_contextid: 0,
-                      item_assetid: 0,
-                      customization_type: showcaseconfig[2],
-                      slot: n,
-                      sessionid: formd[0].value
-                    };
-                  } else {
-                    requestdata = {
-                      appid: showcaseconfig[3][n]["appid"],
-                      item_contextid: showcaseconfig[3][n]["item_contextid"],
-                      item_assetid: showcaseconfig[3][n]["item_assetid"],
-                      customization_type: showcaseconfig[2],
-                      slot: n,
-                      sessionid: formd[0].value
-                    };
+							if (showcaseconfig[0]) {
+								for (var n = 0; n < showcaseconfig[1]; n++) {
+									var requestdata;
+									if (showcaseconfig[3][n] == undefined) {
+										requestdata = {
+											appid: 0,
+											item_contextid: 0,
+											item_assetid: 0,
+											customization_type: showcaseconfig[2],
+											slot: n,
+											sessionid: formd[0].value
+										};
+									} else {
+										requestdata = {
+											appid: showcaseconfig[3][n]["appid"],
+											item_contextid: showcaseconfig[3][n]["item_contextid"],
+											item_assetid: showcaseconfig[3][n]["item_assetid"],
+											customization_type: showcaseconfig[2],
+											slot: n,
+											sessionid: formd[0].value
+										};
 
-                  }
+									}
 
-                  self._myProfile("ajaxsetshowcaseconfig", requestdata, function (err, response, body) {
-                    if (settings.customURL) {
-                      delete selfe._profileURL;
-                    }
+									self._myProfile("ajaxsetshowcaseconfig", requestdata, function (err, response, body) {
+										if (settings.customURL) {
+											delete selfe._profileURL;
+										}
 
-                    if (err || response.statusCode != 200) {
-                      if (callback) {
-                        callback(err || new Error("HTTP error " + response.statusCode));
-                      }
+										if (err || response.statusCode != 200) {
+											if (callback) {
+												callback(err || new Error("HTTP error " + response.statusCode));
+											}
 
-                      return;
-                    }
+											return;
+										}
 
-                    // Check for an error
-                    var $ = Cheerio.load(body);
-                    var error = $('#errorText .formRowFields');
-                    if (error) {
-                      error = error.text().trim();
-                      if (error) {
-                        if (callback) {
-                          callback(new Error(error));
-                        }
+										// Check for an error
+										var $ = Cheerio.load(body);
+										var error = $('#errorText .formRowFields');
+										if (error) {
+											error = error.text().trim();
+											if (error) {
+												if (callback) {
+													callback(new Error(error));
+												}
 
-                        return;
-                      }
-                    }
+												return;
+											}
+										}
 
-                    if (callback) {
-                      callback(null);
-                    }
-                  });
-                }
+										if (callback) {
+											callback(null);
+										}
+									});
+								}
 
-              }
-            }
-          break;
+							}
+						}
+					break;
 
 			}
 		}

--- a/components/profile.js
+++ b/components/profile.js
@@ -55,10 +55,8 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 
 		var values = {};
 		var formd = form.serializeArray();
-		var i = 0;
-		form.serializeArray().forEach(function (item) {
+		form.serializeArray().forEach(function (item, i) {
 			values[item.name] = i;
-			i++;
 		});
 		var out = [];
 		var requiredvalues = ["sessionID", "type", "weblink_1_title", "weblink_1_url", "weblink_2_title", "weblink_2_url", "weblink_3_title", "weblink_3_url", "personaName", "real_name", "country", "state", "city", "customURL", "summary", "profile_background", "favorite_badge_badgeid", "favorite_badge_communityitemid", "primary_group_steamid"];
@@ -118,7 +116,7 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 
 				case 'featuredBadge':
 					// Currently, game badges aren't supported
-						out[16].value = settings[i];
+					out[16].value = settings[i];
 					break;
 
 				case 'primaryGroup':
@@ -358,107 +356,107 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 								}
 								break;
 
-								case 'games':
+							case 'games':
+								out.push({
+									"name": "profile_showcase[]",
+									"value": "2"
+								});
+
+								if (settings[i][type]["values"].hasOwnProperty("games")) {
+									showcaseconfig.supplied = true;
+									showcaseconfig.numberofrequests = 4;
+									showcaseconfig.showcasetype = 2;
+									showcaseconfig.itemarray = settings[i][type]["values"]["games"];
+								}
+								break;
+
+							case 'ownguides':
+								out.push({
+									"name": "profile_showcase[]",
+									"value": "16"
+								});
+
+								for (var n = 0; n < 4; n++) {
+									var defaultval = ["", ""];
+									if (settings[i][type]["values"][n] != undefined) {
+										defaultval = [settings[i][type]["values"][n]["appid"], settings[i][type]["values"][n]["publishedfileid"]];
+									}
 									out.push({
-										"name": "profile_showcase[]",
-										"value": "2"
+										"name": "rgShowcaseConfig[16][" + n + "][appid]",
+										"value": defaultval[0]
 									});
-
-									if (settings[i][type]["values"].hasOwnProperty("games")) {
-										showcaseconfig.supplied = true;
-										showcaseconfig.numberofrequests = 4;
-										showcaseconfig.showcasetype = 2;
-										showcaseconfig.itemarray = settings[i][type]["values"]["games"];
-									}
-									break;
-
-								case 'ownguides':
 									out.push({
-										"name": "profile_showcase[]",
-										"value": "16"
+										"name": "rgShowcaseConfig[16][" + n + "][publishedfileid]",
+										"value": defaultval[1]
 									});
+								}
+								break;
 
-									for (var n = 0; n < 4; n++) {
-										var defaultval = ["", ""];
-										if (settings[i][type]["values"][n] != undefined) {
-											defaultval = [settings[i][type]["values"][n]["appid"], settings[i][type]["values"][n]["publishedfileid"]];
-										}
-										out.push({
-											"name": "rgShowcaseConfig[16][" + n + "][appid]",
-											"value": defaultval[0]
-										});
-										out.push({
-											"name": "rgShowcaseConfig[16][" + n + "][publishedfileid]",
-											"value": defaultval[1]
-										});
+							case 'ownguides':
+								out.push({
+									"name": "profile_showcase[]",
+									"value": "12"
+								});
+
+								for (var n = 0; n < 5; n++) {
+									var defaultval = ["", ""];
+									if (settings[i][type]["values"][n] != undefined) {
+										defaultval = [settings[i][type]["values"][n]["appid"], settings[i][type]["values"][n]["publishedfileid"]];
 									}
-									break;
-
-								case 'ownguides':
 									out.push({
-										"name": "profile_showcase[]",
-										"value": "12"
+										"name": "rgShowcaseConfig[12][" + n + "][appid]",
+										"value": defaultval[0]
 									});
+									out.push({
+										"name": "rgShowcaseConfig[12][" + n + "][publishedfileid]",
+										"value": defaultval[1]
+									});
+								}
+								break;
+						}
 
-									for (var n = 0; n < 5; n++) {
-										var defaultval = ["", ""];
-										if (settings[i][type]["values"][n] != undefined) {
-											defaultval = [settings[i][type]["values"][n]["appid"], settings[i][type]["values"][n]["publishedfileid"]];
-										}
-										out.push({
-											"name": "rgShowcaseConfig[12][" + n + "][appid]",
-											"value": defaultval[0]
-										});
-										out.push({
-											"name": "rgShowcaseConfig[12][" + n + "][publishedfileid]",
-											"value": defaultval[1]
-										});
-									}
-									break;
-							}
+						if (showcaseconfig.supplied) {
+							for (var n = 0; n < showcaseconfig.numberofrequests; n++) {
+								var requestdata;
+								if (showcaseconfig.itemarray[n] == undefined) {
+									requestdata = {
+										appid: 0,
+										item_contextid: 0,
+										item_assetid: 0,
+										customization_type: showcaseconfig.showcasetype,
+										slot: n,
+										sessionid: formd[0].value
+									};
+								} else {
+									requestdata = {
+										appid: showcaseconfig.itemarray[n]["appid"],
+										item_contextid: showcaseconfig.itemarray[n]["item_contextid"],
+										item_assetid: showcaseconfig.itemarray[n]["item_assetid"],
+										customization_type: showcaseconfig.showcasetype,
+										slot: n,
+										sessionid: formd[0].value
+									};
 
-							if (showcaseconfig.supplied) {
-								for (var n = 0; n < showcaseconfig.numberofrequests; n++) {
-									var requestdata;
-									if (showcaseconfig.itemarray[n] == undefined) {
-										requestdata = {
-											appid: 0,
-											item_contextid: 0,
-											item_assetid: 0,
-											customization_type: showcaseconfig.showcasetype,
-											slot: n,
-											sessionid: formd[0].value
-										};
-									} else {
-										requestdata = {
-											appid: showcaseconfig.itemarray[n]["appid"],
-											item_contextid: showcaseconfig.itemarray[n]["item_contextid"],
-											item_assetid: showcaseconfig.itemarray[n]["item_assetid"],
-											customization_type: showcaseconfig.showcasetype,
-											slot: n,
-											sessionid: formd[0].value
-										};
-
-									}
-
-									setTimeout(self._myProfile.bind(self,"ajaxsetshowcaseconfig", requestdata, function (err, response, body) {
-
-										if (err || response.statusCode != 200  && this.showerrors) {
-											if(err){
-												err.message += " | Happened while updating specific showcase items.";
-											}
-
-											if (callback && !this.error) {
-												callback(err || new Error("HTTP error " + response.statusCode + " | Happened while updating specific showcase items."));
-											}
-											this.error = true;
-											return;
-										}
-									}.bind(errorcontrol)), n * 1500);
 								}
 
+								setTimeout(self._myProfile.bind(self,"ajaxsetshowcaseconfig", requestdata, function (err, response, body) {
+
+									if (err || response.statusCode != 200  && this.showerrors) {
+										if(err){
+											err.message += " | Happened while updating specific showcase items.";
+										}
+
+										if (callback && !this.error) {
+											callback(err || new Error("HTTP error " + response.statusCode + " | Happened while updating specific showcase items."));
+										}
+										this.error = true;
+										return;
+									}
+								}.bind(errorcontrol)), n * 1500);
 							}
 						}
+
+					}
 					break;
 
 			}

--- a/components/profile.js
+++ b/components/profile.js
@@ -129,6 +129,7 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 					break;
 
 				case 'showcases':
+					var num_of_requests = 0;
 					for (var type in settings[i]) {
 						//Variable used to easily make request to`ajaxsetshowcaseconfig` for showcases like trade, items, ...
 						var showcaseconfig = {
@@ -417,6 +418,7 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 
 						if (showcaseconfig.supplied) {
 							for (var n = 0; n < showcaseconfig.numberofrequests; n++) {
+								num_of_requests++;
 								var requestdata;
 								if (showcaseconfig.itemarray[n] == undefined) {
 									requestdata = {
@@ -452,7 +454,7 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 										this.error = true;
 										return;
 									}
-								}.bind(errorcontrol)), n * 1500);
+								}.bind(errorcontrol)), num_of_requests * 1500);
 							}
 						}
 

--- a/components/profile.js
+++ b/components/profile.js
@@ -1,6 +1,7 @@
 const Cheerio = require('cheerio');
 const FS = require('fs');
 const SteamID = require('steamid');
+const Param = require('jquery-param');
 
 const Helpers = require('./helpers.js');
 const SteamCommunity = require('../index.js');
@@ -53,10 +54,8 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 			return;
 		}
 
-		var values = {};
-		form.serializeArray().forEach(function(item) {
-			values[item.name] = item.value;
-		});
+		var formd = form.serializeArray();
+		var out = [].concat(formd.slice(0,19));
 
 		for(var i in settings) {
 			if(!settings.hasOwnProperty(i)) {
@@ -65,57 +64,413 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 
 			switch(i) {
 				case 'name':
-					values.personaName = settings[i];
-					break;
+          out[8] = {
+            "name": formd[8].name,
+            "value": settings[i]
+          };
+	        break;
 
-				case 'realName':
-					values.real_name = settings[i];
-					break;
+        case 'realName':
+          out[9] = {
+            "name": formd[9].name,
+            "value": settings[i]
+          };
+          break;
 
-				case 'summary':
-					values.summary = settings[i];
-					break;
+        case 'summary':
+	        out[14] = {
+	          "name": formd[14].name,
+	          "value": settings[i]
+	        };
+          break;
 
-				case 'country':
-					values.country = settings[i];
-					break;
+        case 'country':
+          out[10] = {
+            "name": formd[10].name,
+            "value": settings[i]
+          };
+          break;
 
-				case 'state':
-					values.state = settings[i];
-					break;
+        case 'state':
+          out[11] = {
+            "name": formd[11].name,
+            "value": settings[i]
+          };
+          break;
 
-				case 'city':
-					values.city = settings[i];
-					break;
+        case 'city':
+          out[12] = {
+            "name": formd[12].name,
+            "value": settings[i]
+          };
+          break;
 
-				case 'customURL':
-					values.customURL = settings[i];
-					break;
+        case 'customURL':
+          out[13] = {
+            "name": formd[13].name,
+            "value": settings[i]
+          };
+          break;
 
-				case 'background':
-					// The assetid of our desired profile background
-					values.profile_background = settings[i];
-					break;
+        case 'background':
+          // The assetid of our desired profile background
+          out[15] = {
+            "name": formd[15].name,
+            "value": settings[i]
+          };
+          break;
 
-				case 'featuredBadge':
-					// Currently, game badges aren't supported
-					values.favorite_badge_badgeid = settings[i];
-					break;
+        case 'featuredBadge':
+          // Currently, game badges aren't supported
+            out[16] = {
+              "name": formd[16].name,
+              "value": settings[i]
+            };
+          break;
 
-				case 'primaryGroup':
-					if(typeof settings[i] === 'object' && settings[i].getSteamID64) {
-						values.primary_group_steamid = settings[i].getSteamID64();
-					} else {
-						values.primary_group_steamid = new SteamID(settings[i]).getSteamID64();
-					}
+        case 'primaryGroup':
+          if (typeof settings[i] === 'object' && settings[i].getSteamID64) {
+            out[18] = {
+              "name": formd[18].name,
+              "value": settings[i].getSteamID64()
+            };
+          } else {
+            out[18] = {
+              "name": formd[18].name,
+              "value": new SteamID(settings[i]).getSteamID64()
+            };
+          }
 
-					break;
+          break;
 
-				// TODO: profile showcases
+        case 'showcases':
+          for (var t in settings[i]) {
+            var showcaseconfig = [false,0,0,[]];
+
+            switch (settings[i][t].showcase) {
+
+              case 'infobox':
+                out.push({
+                  "name": "profile_showcase[]",
+                  "value": "8"
+                });
+                out.push({
+                  "name": "rgShowcaseConfig[8][0][title]",
+                  "value": settings[i][t]["values"]["title"]
+                });
+                out.push({
+                  "name": "rgShowcaseConfig[8][0][notes]",
+                  "value": settings[i][t]["values"]["notes"]
+                });
+                break;
+
+              case 'artwork':
+                out.push({
+                  "name": "profile_showcase[]",
+                  "value": "13"
+                });
+                for (var n = 0; n < 4; n++) {
+                  out.push({
+                    "name": "rgShowcaseConfig[13][" + n + "][publishedfileid]",
+                    "value": settings[i][t]["values"][n] || ""
+                  });
+                }
+                break;
+
+              case 'trade':
+                out.push({
+                  "name": "profile_showcase[]",
+                  "value": "4"
+                });
+                out.push({
+                  "name": "rgShowcaseConfig[4][6][notes]",
+                  "value": settings[i][t]["values"]["notes"]
+                });
+
+                if (settings[i][t]["values"].hasOwnProperty("items")) {
+                  showcaseconfig = [true, 6, 4, settings[i][t]["values"]["items"]];
+                }
+                break;
+
+              case 'items':
+                out.push({
+                  "name": "profile_showcase[]",
+                  "value": "3"
+                });
+
+                if (settings[i][t]["values"].hasOwnProperty("items")) {
+                  showcaseconfig = [true, 10, 3, settings[i][t]["values"]["items"]];
+                }
+                break;
+
+              case 'game':
+                out.push({
+                  "name": "profile_showcase[]",
+                  "value": "6"
+                });
+                out.push({
+                  "name": "rgShowcaseConfig[6][0][appid]",
+                  "value": settings[i][t]["values"]["appid"]
+                });
+                break;
+
+              case 'badge':
+                out.push({
+                  "name": "profile_showcase[]",
+                  "value": "5"
+                });
+                var styles = ["rare","selected",null,"recent","random"];
+                out.push({
+                  "name": "profile_showcase_style_5",
+                  "value": styles.indexOf(settings[i][t]["values"]["style"])
+                });
+
+                if (settings[i][t]["values"].hasOwnProperty("badges")){
+                  for(var n = 0; n < 6; n++){
+										var defaultval = ["", "", ""];
+		                if (settings[i][t]["values"]["badges"][n] != undefined) {
+		                  defaultval = [settings[i][t]["values"]["badges"][n]["badgeid"], settings[i][t]["values"]["badges"][n]["appid"], settings[i][t]["values"]["badges"][n]["border_color"]];
+		                }
+		                out.push({
+		                  "name": "rgShowcaseConfig[5][" + n + "][badgeid]",
+		                  "value": defaultval[0]
+		                });
+		                out.push({
+		                  "name": "rgShowcaseConfig[5][" + n + "][appid]",
+		                  "value": defaultval[1]
+		                });
+		                out.push({
+		                  "name": "rgShowcaseConfig[5][" + n + "][border_color]",
+		                  "value": defaultval[2]
+		                });
+                  }
+                }
+
+                break;
+
+              case 'rareachievements':
+                out.push({
+                  "name": "profile_showcase[]",
+                  "value": "1"
+                });
+                break;
+
+              case 'screenshot':
+                out.push({
+                  "name": "profile_showcase[]",
+                  "value": "7"
+                });
+                for (var n = 0; n < 4; n++) {
+                  out.push({
+                    "name": "rgShowcaseConfig[7][" + n + "][publishedfileid]",
+                    "value": settings[i][t]["values"][n] || ""
+                  });
+                }
+                break;
+
+              case 'group':
+                out.push({
+                  "name": "profile_showcase[]",
+                  "value": "9"
+                });
+                if (typeof settings[i][t]["values"]["groupid"] === 'object' && settings[i][t]["values"]["groupid"].getSteamID64) {
+                  out.push({
+                    "name": "rgShowcaseConfig[9][0][accountid]",
+                    "value": settings[i][t]["values"]["groupid"].getSteamID64()
+                  });
+                } else {
+                  out.push({
+                    "name": "rgShowcaseConfig[9][0][accountid]",
+                    "value": new SteamID(settings[i][t]["values"]["groupid"]).getSteamID64()
+                  });
+                }
+                break;
+
+              case 'review':
+                out.push({
+                  "name": "profile_showcase[]",
+                  "value": "10"
+                });
+                out.push({
+                  "name": "rgShowcaseConfig[10][0][appid]",
+                  "value": settings[i][t]["values"]["appid"]
+                });
+                break;
+
+              case 'workshop':
+                out.push({
+                  "name": "profile_showcase[]",
+                  "value": "11"
+                });
+                out.push({
+                  "name": "rgShowcaseConfig[11][0][appid]",
+                  "value": settings[i][t]["values"]["appid"]
+                });
+                out.push({
+                  "name": "rgShowcaseConfig[11][0][publishedfileid]",
+                  "value": settings[i][t]["values"]["publishedfileid"]
+                });
+                break;
+
+              case 'guide':
+                out.push({
+                  "name": "profile_showcase[]",
+                  "value": "15"
+                });
+                out.push({
+                  "name": "rgShowcaseConfig[15][0][appid]",
+                  "value": settings[i][t]["values"]["appid"]
+                });
+                out.push({
+                  "name": "rgShowcaseConfig[15][0][publishedfileid]",
+                  "value": settings[i][t]["values"]["publishedfileid"]
+                });
+                break;
+
+              case 'achievements':
+                out.push({
+                  "name": "profile_showcase[]",
+                  "value": "17"
+                });
+                if (settings[i][t]["values"].hasOwnProperty("achievements")) {
+                  for (var n = 0; n < 7; n++) {
+										var defaultval = ["", ""];
+		                if (settings[i][t]["values"]["achievements"][n] != undefined) {
+		                  defaultval = [settings[i][t]["values"]["achievements"][n]["appid"], settings[i][t]["values"]["achievements"][n]["title"]];
+		                }
+		                out.push({
+		                  "name": "rgShowcaseConfig[17][" + n + "][appid]",
+		                  "value": defaultval[0]
+		                });
+		                out.push({
+		                  "name": "rgShowcaseConfig[17][" + n + "][title]",
+		                  "value": defaultval[1]
+		                });
+                  }
+                }
+              	break;
+
+								case 'games':
+                  out.push({
+                    "name": "profile_showcase[]",
+                    "value": "2"
+                  });
+
+                  if (settings[i][t]["values"].hasOwnProperty("games")) {
+                    showcaseconfig = [true, 4, 2, settings[i][t]["values"]["games"]];
+                  }
+                  break;
+
+                case 'ownguides':
+                  out.push({
+                    "name": "profile_showcase[]",
+                    "value": "16"
+                  });
+
+                  for (var n = 0; n < 4; n++) {
+                    var defaultval = ["", ""];
+		                if (settings[i][t]["values"][n] != undefined) {
+		                  defaultval = [settings[i][t]["values"][n]["appid"], settings[i][t]["values"][n]["publishedfileid"]];
+		                }
+                    out.push({
+                      "name": "rgShowcaseConfig[16][" + n + "][appid]",
+                      "value": defaultval[0]
+                    });
+                    out.push({
+                      "name": "rgShowcaseConfig[16][" + n + "][publishedfileid]",
+                      "value": defaultval[1]
+                    });
+                  }
+                  break;
+
+                case 'ownguides':
+                  out.push({
+                    "name": "profile_showcase[]",
+                    "value": "12"
+                  });
+
+                  for (var n = 0; n < 5; n++) {
+                    var defaultval = ["", ""];
+                    if (settings[i][t]["values"][n] != undefined) {
+                      defaultval = [settings[i][t]["values"][n]["appid"], settings[i][t]["values"][n]["publishedfileid"]];
+                    }
+                    out.push({
+                      "name": "rgShowcaseConfig[12][" + n + "][appid]",
+                      "value": defaultval[0]
+                    });
+                    out.push({
+                      "name": "rgShowcaseConfig[12][" + n + "][publishedfileid]",
+                      "value": defaultval[1]
+                    });
+                  }
+                  break;
+              }
+
+              if (showcaseconfig[0]) {
+                for (var n = 0; n < showcaseconfig[1]; n++) {
+                  var requestdata;
+                  if (showcaseconfig[3][n] == undefined) {
+                    requestdata = {
+                      appid: 0,
+                      item_contextid: 0,
+                      item_assetid: 0,
+                      customization_type: showcaseconfig[2],
+                      slot: n,
+                      sessionid: formd[0].value
+                    };
+                  } else {
+                    requestdata = {
+                      appid: showcaseconfig[3][n]["appid"],
+                      item_contextid: showcaseconfig[3][n]["item_contextid"],
+                      item_assetid: showcaseconfig[3][n]["item_assetid"],
+                      customization_type: showcaseconfig[2],
+                      slot: n,
+                      sessionid: formd[0].value
+                    };
+
+                  }
+
+                  self._myProfile("ajaxsetshowcaseconfig", requestdata, function (err, response, body) {
+                    if (settings.customURL) {
+                      delete selfe._profileURL;
+                    }
+
+                    if (err || response.statusCode != 200) {
+                      if (callback) {
+                        callback(err || new Error("HTTP error " + response.statusCode));
+                      }
+
+                      return;
+                    }
+
+                    // Check for an error
+                    var $ = Cheerio.load(body);
+                    var error = $('#errorText .formRowFields');
+                    if (error) {
+                      error = error.text().trim();
+                      if (error) {
+                        if (callback) {
+                          callback(new Error(error));
+                        }
+
+                        return;
+                      }
+                    }
+
+                    if (callback) {
+                      callback(null);
+                    }
+                  });
+                }
+
+              }
+            }
+          break;
+
 			}
 		}
 
-		self._myProfile("edit", values, function(err, response, body) {
+		self._myProfile("edit", Param(out), function(err, response, body) {
 			if (settings.customURL) {
 				delete self._profileURL;
 			}

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
 		"xml2js": "^0.4.11",
 		"cheerio": "0.22.0",
 		"async": "^2.1.4",
-		"steam-totp": "^1.3.0",
-		"jquery-param": "1.0.1"
+		"steam-totp": "^1.3.0"
 	},
 	"engines": {
 		"node": ">=4.0.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
 		"xml2js": "^0.4.11",
 		"cheerio": "0.22.0",
 		"async": "^2.1.4",
-		"steam-totp": "^1.3.0"
+		"steam-totp": "^1.3.0",
+		"jquery-param": "1.0.1"
 	},
 	"engines": {
 		"node": ">=4.0.0"


### PR DESCRIPTION
The option "showcases" was added to editProfile().

For this option you have to submit an array of objects. These objects have all the property "showcase", and some need the property "values". They will be displayed in the order in which they were in the array.

Possible showcase values:
infobox, artwork, trade, items, game, badge, rareachievements, screenshot, group, review, workshop, guide, achievements, games, ownguides, ownworkshop, (steam game ones like salien, but these will be obsolent at some point so not included here)

Information about these:
* infobox:
  * values: "title" and "notes"
* artwork:
  * values: a single array with up to 4 publishedfileids (f.e. just copy them from the page of your artwork)
* trade:
  * values: "notes"
* items:
  * values: none
* game:
  * values: a single number which is the appid
* badge:
  * values: "style" which can be one of the following - [rare, selected, recent, random], "badges" which is an array of objects in the following manner - {"appid": ..., "badgeid": ..., "border_color": ...} (although I do not know the influence of border_color, if the badge is not a game badge, fill only badgeid, if it is a badge from a game the badgeid is 1 and you have to fill in appid) up to 6
* rareachievements:
  * values: none
* screenshot:
  * values: a single array with up to 4 publishedfileids
* group:
  * values: SteamID
* review:
  * values: a single number which is the appid of the game where you want to display your review
* workshop:
  * values: "appid" of the game, "publishedfileid" of the workshop item
* guide:
  * values: "appid" of the game, "publishedfileid" of the guide
* achievements:
  * values: "achievements" which is an array of objects in the following manner - {"appid": ..., "title": ...} (for the title either get it manually or use `https://steamcommunity.com/id/<Steam ID>/ajaxgetachievementsforgame/<app id>`) up to 7
* games:
  * values: none
* ownguides:
  * values: an array of objects in the following manner - {"appid": ..., "publishedfileid": ...} up to 4
* ownworkshop:
  * values: an array of objects in the following manner - {"appid": ..., "publishedfileid": ...} up to 5
  
Example of usage:
```js
community.editProfile({
    "realName": "Bot",
    "summary": "Summary",
    "showcases": [{
        "showcase": "game",
		"values": 440
    }, {
        "showcase": "achievements"
    }, {
        "showcase": "trade",
        "values": {
            "notes": "Trade notes."
        }
    }, {
        "showcase": "infobox",
        "values": {
            "title": "24/7",
            "notes": "Items: ...."
        }
    }, {
        "showcase": "games",
    }]
}, (err) => {
    if (err) console.log(err);
});
```  

Additionally the method `editShowcaseItem()` was added, which takes 4 options.
These are showcase, slot, item and callback.
Currently there are 3 types of showcases which you can edit with this function (because they use the 
`ajaxsetshowcaseconfig` endpoint). These are:
* "trade"
  * has 6 slots
  * takes an object in the following manner as item: `{"appid": ...,  "item_contextid": ..., "item_assetid": ...}`
* "items"
  * has 10 slots
  * takes an object in the following manner as item: `{"appid": ...,  "item_contextid": ..., "item_assetid": ...}`
* "games"
  * has 4 slots
  * takes an object in the following manner as item: `{"appid": ...}`

Example: 

```js 
community.editShowcaseItem("trade", 2, {
	"appid": 440,
	"item_contextid": 2,
	"item_assetid": 670000
}, (err) => {
	if(err){
	console.log(err)
	}
});
```

Some showcases of course only work if you fulfill the requirements, meaning it could be that I am missing some.