### PR TITLE
Added deleteUserComment and getUserComments

### DIFF
--- a/classes/CSteamUser.js
+++ b/classes/CSteamUser.js
@@ -152,8 +152,8 @@ CSteamUser.prototype.deleteComment = function(commentID, callback) {
 	this._community.deleteUserComment(this.steamID, commentID, callback);
 };
 
-CSteamUser.prototype.getUserComments = function(options, callback) {
-	this._community.postUserComment(this.steamID, options, callback);
+CSteamUser.prototype.getComments = function(options, callback) {
+	this._community.getUserComments(this.steamID, options, callback);
 };
 
 CSteamUser.prototype.inviteToGroup = function(groupID, callback) {

--- a/classes/CSteamUser.js
+++ b/classes/CSteamUser.js
@@ -148,6 +148,14 @@ CSteamUser.prototype.comment = function(message, callback) {
 	this._community.postUserComment(this.steamID, message, callback);
 };
 
+CSteamUser.prototype.deleteComment = function(commentID, callback) {
+	this._community.deleteUserComment(this.steamID, commentID, callback);
+};
+
+CSteamUser.prototype.getUserComments = function(options, callback) {
+	this._community.postUserComment(this.steamID, options, callback);
+};
+
 CSteamUser.prototype.inviteToGroup = function(groupID, callback) {
 	this._community.inviteUserToGroup(this.steamID, groupID, callback);
 };

--- a/components/users.js
+++ b/components/users.js
@@ -232,18 +232,22 @@ SteamCommunity.prototype.getUserComments = function(userID, options, callback) {
 
 		if(body.success) {
 			const $ = Cheerio.load(body.comments_html);
-			const comments = $(".commentthread_comment.responsive_body_text[id]").map((i, elem) => ({
-				id: $(elem).attr("id").split("_")[1],
-				author: {
-					id: new SteamID("[U:1:" + $(elem).find("[data-miniprofile]").data("miniprofile") + "]"),
-					name: $(elem).find("bdi").text(),
-					avatar: $(elem).find(".playerAvatar img[src]").attr("src"),
-					state: $(elem).find(".playerAvatar").attr("class").split(" ").pop()
-				},
-				date: new Date($(elem).find(".commentthread_comment_timestamp").data("timestamp") * 1000),
-				text: $(elem).find(".commentthread_comment_text").text(),
-				html:  $(elem).find(".commentthread_comment_text").html()
-			})).get();
+			const comments = $(".commentthread_comment.responsive_body_text[id]").map((i, elem) => {
+				var $elem = $(elem),
+					$commentContent = $elem.find(".commentthread_comment_text");
+				return {
+					id: $elem.attr("id").split("_")[1],
+					author: {
+						id: new SteamID("[U:1:" + $elem.find("[data-miniprofile]").data("miniprofile") + "]"),
+						name: $elem.find("bdi").text(),
+						avatar: $elem.find(".playerAvatar img[src]").attr("src"),
+						state: $elem.find(".playerAvatar").attr("class").split(" ").pop()
+					},
+					date: new Date($elem.find(".commentthread_comment_timestamp").data("timestamp") * 1000),
+					text: $commentContent.text(),
+					html: $commentContent.html()
+				}
+			}).get();
 
 			callback(null, comments, body.total_count);
 		} else if(body.error) {

--- a/components/users.js
+++ b/components/users.js
@@ -209,16 +209,16 @@ SteamCommunity.prototype.getUserComments = function(userID, options, callback) {
 		options = {};
 	}
 
-	var self = this;
+	var form = Object.assign({
+		"start": 0,
+		"count": 0,
+		"feature2": -1,
+		"sessionid": this.getSessionID()
+	}, options);
+
 	this.httpRequestPost({
 		"uri": "https://steamcommunity.com/comment/Profile/render/" + userID.toString() + "/-1",
-		"form": {
-			"start": 0,
-			"count": 0,
-			"feature2": -1,
-			"sessionid": this.getSessionID(),
-			...options
-		},
+		"form": form,
 		"json": true
 	}, function(err, response, body) {
 		if(!callback) {


### PR DESCRIPTION
Resolves https://github.com/DoctorMcKay/node-steamcommunity/issues/219 and resolves https://github.com/DoctorMcKay/node-steamcommunity/issues/208

The callback of `postUserComment` now returns the `commentID` as second parameter.
The function `deleteUserComment` takes `userID`, `commentID` and a callback as parameters respectively.
The function `getUserComments` takes `userID`, `options` and a callback as parameters respectively, where `options` is an object with `start`, `count`, etc.