### PR TITLE
Implement basic workshop community functionality

### DIFF
--- a/classes/CCommunityComment.js
+++ b/classes/CCommunityComment.js
@@ -1,0 +1,83 @@
+var SteamCommunity = require('../index.js');
+var Cheerio = require('cheerio');
+var SteamID = require('steamid');
+
+/**
+ * Representation of a comment in the community, e.g. on a profile page or a workshop item
+ * @param {SteamCommunity} community
+ * @param {SteamCommunity.CWorkshopItem} owner The entity we originated from. Currently only workshop item is supported
+ */
+function CCommunityComment(community, owner) {
+    this._community = community;
+    this._owner = owner;
+
+    /** Filled out by .fromHTML() */
+    /** @type {string} */
+    this.id = null;
+    /** @type {SteamID} */
+    this.submitter = null;
+    /** @type {string} The body of the comment as HTML */
+    this.content = null;
+    /** @type {Date} The time at which the comment was posted */
+    this.time = null;
+}
+
+/**
+ * Parses a comment from its HTML
+ * @param {SteamCommunity} community
+ * @param {SteamCommunity.CWorkshopItem} owner The entity it originated from. Currently only workshop item is supported
+ * @returns {CCommunityComment}
+ */
+CCommunityComment.fromHTML = function(community, owner, html) {
+    var $ = Cheerio.load(html);
+    var comment = new SteamCommunity.CCommunityComment(community, owner);
+    var id = /comment_(\d+)/.exec($.root().children().first().attr('id'));
+    if (!id) { throw new Error("Could not find ID of comment"); }
+    comment.id = id[1];
+    comment.submitter = SteamID.fromIndividualAccountID($('.commentthread_author_link').attr('data-miniprofile'));
+    comment.content = $('.commentthread_comment_text').html();
+    comment.time = new Date(+$('.commentthread_comment_timestamp').attr('data-timestamp') * 1000);
+    return comment;
+};
+
+CCommunityComment.prototype._getActionUrl = function(action) {
+    if (this._owner instanceof SteamCommunity.CWorkshopItem) {
+        return "https://steamcommunity.com/comment/PublishedFile_Public/"+action+"/"+this._owner.creators[0].getSteamID64()+"/"+this._owner.id+"/";
+    }
+
+    throw new Error("Unknown owner "+this._owner);
+};
+
+/**
+ * Deletes the comment for good. Only call if you're for real.
+ * @param {(err: Error) => any} callback
+ */
+CCommunityComment.prototype.delete = function(callback) {
+    if (!(callback instanceof Function)) {
+        throw new Error("Callback must be a function");
+    }
+    this._community.httpRequestPost(
+        {
+            "uri": this._getActionUrl('delete'),
+            "form": {
+                start: 0,
+                gidcomment: this.id,
+                sessionid: this._community.getSessionID()
+            },
+            "json": true
+        },
+        function(err, response, body) {
+            if (err) {
+                callback(err);
+                return;
+            }
+            if (body.success !== true) {
+                callback(new Error(JSON.stringify(body)));
+                return;
+            }
+            callback(null);
+        }
+    );
+};
+
+SteamCommunity.CCommunityComment = CCommunityComment;

--- a/classes/CWorkshopItem.js
+++ b/classes/CWorkshopItem.js
@@ -1,0 +1,107 @@
+var SteamCommunity = require('../index.js');
+var Cheerio = require('cheerio');
+var SteamID = require('steamid');
+
+/**
+ * Representation of a workshop item
+ * @param {SteamCommunity} community
+ * @param {string} id The file id, usually found in the URL
+ */
+function CWorkshopItem(community, id) {
+    this._community = community;
+
+    this.id = id;
+    this.hasInformation = false;
+
+    // information that is filled out by .fetchInformation
+    /** @type {string} */
+    this.title = null;
+    /** @type {string} Item description as HTML */
+    this.description = null;
+    /** @type {SteamID[]} People who created the item */
+    this.creators = null;
+    /** @type {number} Number of ratings on the item */
+    this.numRatings = null;
+    /** @type {number} Number of comments on the item */
+    this.numComments = null;
+}
+
+/**
+ * Fetches information about the workshop item
+ * After the callback is called, the information is available on the CWorkshopItem instance
+ * @param {(err: Error)} callback
+ */
+CWorkshopItem.prototype.fetchInformation = function(callback) {
+    var self = this;
+    this._community.httpRequest(
+        "https://steamcommunity.com/sharedfiles/filedetails/?id="+this.id,
+        function(err, response, body) {
+            if (err) {
+                callback(err);
+                return;
+            }
+
+            var $ = Cheerio.load(body);
+            self.title = $('.workshopItemTitle').text().trim();
+            self.description = $('.workshopItemDescription').html();
+            var $creators = $('.creatorsBlock .persona');
+            self.creators = $creators.map(function(i, creator) {
+                return SteamID.fromIndividualAccountID($(creator).attr('data-miniprofile'));
+            }).get();
+            var numRatings = /(\d+) ratings/.exec($('.numRatings').text());
+            self.numRatings = numRatings ? +numRatings[1] : null;
+            self.numComments = +$('.sectionTab[href*="/comments/"] .tabCount').text();
+
+            self.hasInformation = true;
+            callback(null);
+        }
+    );
+};
+
+/**
+ * Get comments from the page, optionally with a maximum to fetch
+ * @param {number} [max=Infinity] Maximum number of comments to fetch
+ * @param {(err: Error, comments?: SteamCommunity.CCommunityComment[]) => any} callback
+ */
+CWorkshopItem.prototype.getComments = function(max, callback) {
+    if (!this.hasInformation) {
+        callback(new Error("Item must have fetched information first"));
+        return;
+    }
+    if (max instanceof Function) {
+        callback = max;
+        max = this.numComments;
+    }
+
+    var self = this;
+    var url = "https://steamcommunity.com/comment/PublishedFile_Public/render/" + this.creators[0].getSteamID64() + "/" + this.id + "/";
+    this._community.httpRequestPost({
+            "uri": url,
+            "form": {
+                start: 0,
+                count: max,
+                sessionid: this._community.getSessionID(),
+                feature2: "-1"
+            },
+            "json": true
+        },
+        function(err, response, body) {
+            if (err) {
+                callback(err);
+                return;
+            }
+            if (body.success !== true) {
+                callback(new Error(body.error));
+                return;
+            }
+
+            var $ = Cheerio.load(body.comments_html);
+            var comments = $('.commentthread_comment').map(function(i, elm) {
+                return SteamCommunity.CCommunityComment.fromHTML(self._community, self, $.html(elm));
+            }).get();
+            callback(null, comments);
+        }
+    );
+};
+
+SteamCommunity.CWorkshopItem = CWorkshopItem;

--- a/components/workshop.js
+++ b/components/workshop.js
@@ -1,0 +1,63 @@
+var SteamCommunity = require('../index.js');
+var Cheerio = require('cheerio');
+var SteamID = require('steamid');
+var Async = require('async');
+
+/**
+ * Get the items a user has submitted to the workshop
+ * @param {SteamID|string} [userID] If not set, get our own items
+ * @param {(err: Error, items?: SteamCommunity.CWorkshopItem[]) => any} callback
+ */
+SteamCommunity.prototype.getWorkshopItems = function(userID, callback) {
+    if (typeof userID === 'string') {
+		userID = new SteamID(userID);
+    }
+    if (userID instanceof Function) {
+        callback = userID;
+        userID = this.steamID;
+    }
+	if (!userID) {
+		callback(new Error("No SteamID specified and not logged in"));
+		return;
+    }
+
+    var self = this;
+    var items = [];
+    var pageNum = 1;
+
+    // keep asking for pages until we don't have any more pages to fetch
+    Async.doUntil(
+        function(cb) {
+            var url = "https://steamcommunity.com/profiles/" + userID.getSteamID64() + "/myworkshopfiles/?p="+pageNum+"&numberpage=30";
+            self.httpRequest(url, function(err, response, body) {
+                if (err) {
+                    cb(err);
+                    return;
+                }
+
+                var $ = Cheerio.load(body);
+                $('.workshopItem').each(function(i, $element) {
+                    var elm = Cheerio.load($element);
+                    var preview = elm('.ugc');
+                    var id = preview.attr('data-publishedfileid');
+                    items.push(new SteamCommunity.CWorkshopItem(self, id));
+                });
+                if ($('.workshopBrowsePagingControls .pagebtn:last-child:not(.disabled)').length) {
+                    ++pageNum;
+                    cb(null, false);
+                } else {
+                    cb(null, true);
+                }
+            });
+        },
+        function(isFinished) { return isFinished; },
+        // then return the items (or error) we ended up with
+        function(err) {
+            if (err) {
+                callback(err);
+                return;
+            }
+            callback(null, items);
+        }
+    );
+};

--- a/index.js
+++ b/index.js
@@ -543,10 +543,13 @@ require('./components/inventoryhistory.js');
 require('./components/webapi.js');
 require('./components/twofactor.js');
 require('./components/confirmations.js');
+require('./components/workshop.js');
+require('./classes/CCommunityComment.js');
 require('./classes/CMarketItem.js');
 require('./classes/CMarketSearchResult.js');
 require('./classes/CSteamGroup.js');
 require('./classes/CSteamUser.js');
+require('./classes/CWorkshopItem.js');
 
 /**
  @callback SteamCommunity~genericErrorCallback


### PR DESCRIPTION
I needed some basic interaction with the workshop for a spam cleaner I'm developing, and figured you might be interested in merging upstream. If not, no biggie.

Implements the ability to get a list of a users workshop items, and a list of comments on a given workshop item. Uses the two new classes `CWorkshopItem` and `CCommunityComment` to represent the data structures.

I unfortunately couldn't find any web APIs for this, so all of it is done through parsing the website.

---

The following APIs have been added:

## SteamCommunity

#### getWorkshopItems([userID, ]callback)

- `userID` - The user to get workshop items for. If not set, uses the currently logged in user. Can be SteamID or string.
- `callback` - Called when the items have been retrieved
  - `err` - `null` on success, an `Error` object on failure
  - `items` - an array of `CWorkshopItem` objects

## CWorkshopItem

#### title

The title of the item. `null` until `.fetchInformation()` is called.

#### description

The description of the item, as plain HTML. `null` until `.fetchInformation()` is called.

#### creators

An array of `SteamID` objects representing the creators of the item. `null` until `.fetchInformation()` is called.

#### numRatings

Number of ratings of the item. `null` until `.fetchInformation()` is called.

#### numComments

Number of comments on the item. `null` until `.fetchInformation()` is called.

#### fetchInformation(callback)

Fetches information about the workshop from its web page. After the callback is called, the information is available on the `CWorkshopItem` instance.

- `callback` - Called when the information has been retrieved
  - `err` - `null` on success, an `Error` object on failure

#### getComments([max, ]callback)

Gets the comments for the item, optionally with a maximum number to fetch

- `callback` - Called when the comments have been retrieved
  - `err` - `null` on success, an `Error` object on failure
  - `comments` - an array of `CCommunityComment` objects

## CCommunityComment

#### submitter

A `SteamID` object representing the submitter of the comment

#### content

The body of the comment, as plain HTML.

#### time

A `Date` object representing the time the comment was submitted

#### delete(callback)

Deletes the comment.

- `callback` - Called when the comment has been deleted
  - `err` - `null` on success, an `Error` object on failure