### PR TITLE
Add openBoosterPack

### DIFF
--- a/components/market.js
+++ b/components/market.js
@@ -110,6 +110,43 @@ SteamCommunity.prototype.turnItemIntoGems = function(appid, assetid, expectedGem
 };
 
 /**
+ * Open a booster pack.
+ * @param {int} appid
+ * @param {int|string} assetid
+ * @param {function} callback
+ */
+SteamCommunity.prototype.openBoosterPack = function(appid, assetid, callback) {
+	this._myProfile({
+		"endpoint": "ajaxunpackbooster/",
+		"json": true,
+		"checkHttpError": false
+	}, {
+		"appid": appid,
+		"communityitemid": assetid,
+		"sessionid": this.getSessionID()
+	}, (err, res, body) => {
+		if (err) {
+			callback(err);
+			return;
+		}
+
+		if (body.success && body.success != SteamCommunity.EResult.OK) {
+			let err = new Error(body.message || SteamCommunity.EResult[body.success]);
+			err.eresult = err.code = body.success;
+			callback(err);
+			return;
+		}
+
+		if (!body.rgItems) {
+			callback(new Error("Malformed response"));
+			return;
+		}
+
+		callback(null, body.rgItems);
+	})
+};
+
+/**
  * Get details about a gift in your inventory.
  * @param {string} giftID
  * @param {function} callback


### PR DESCRIPTION
Add `openBoosterPack` - implemented in the same way as `getGemValue` and `turnItemIntoGems`.

Errors just like `getGemValue` and `turnItemIntoGems` by checking the success state, if successful Steam responds with an array with info on the opened cards in this format - this response is the response callback for the function:

```javascript
[
	{
		image: 'https://steamcommunity-a.akamaihd.net/economy/image/IzMF03bk9WpSBq-S-ekoE33L-iLqGFHVaU25ZzQNQcXdA3g5gMEPvUZZEfSMJ6dESN8p_2SVTY7V2NoNxXEKmChCIzb02ClYd_Z5K43PzQT8pL-LSiLyMGGXe3KPGgo6ROdZY2HY-mCi4u3FQ2rMQ-4rFlwBK6BX9mFLI4nXaARvi8VfrneHnkl8GRN1J8ERJwnjmHFANO10zSARJpJUnHfydJ2PjFxmbhJpXr-yV7rDbNP3wTFkA01xWa0bIIswqRk',
		name: 'Ursus',
		series: 1,
		foil: false
	},
	{
		image: 'https://steamcommunity-a.akamaihd.net/economy/image/IzMF03bk9WpSBq-S-ekoE33L-iLqGFHVaU25ZzQNQcXdA3g5gMEPvUZZEfSMJ6dESN8p_2SVTY7V2NoNxXEKmChCIzb02ClDYPxhOdmAyQj6pufQTXWmPzaSfHCPH1o4S7FaYWvZ_zWk4-vGQm6dE-l-EQEEdPBXp2dPNNfJYUUrhthJr2CqqE1wHxEtL5BCJ1i9kiYWYrh1mSQTJshbnyGjJMbQ01ZhbEA-WbzgA73EboL3wn46HUQwCeYXZQ7oK0XY',
		name: 'Neymar',
		series: 1,
		foil: false
	},
	{
		image: 'https://steamcommunity-a.akamaihd.net/economy/image/IzMF03bk9WpSBq-S-ekoE33L-iLqGFHVaU25ZzQNQcXdA3g5gMEPvUZZEfSMJ6dESN8p_2SVTY7V2NoNxXEKmChCIzb02ClDYPxhOdmAyQj6pufQTXWmPzaSfHCPH1o4S7FaYWvZ_zWk4-vGQm6dE-l-EQEEdPBXp2dPNNfJYUUrhthJr2CqqE1wHxEtL5BCJ1i9kiYWYrh1mSQTJshbnyGjJMbQ01ZhbEA-WbzgA73EboL3wn46HUQwCeYXZQ7oK0XY',
		name: 'Neymar',
		series: 1,
		foil: false
	}
]

```

The doc would read something like this:

### openBoosterPack(appid, assetid, callback)
- `appid` - The AppID of the game to which the booster pack in question belongs
- `assetid` - The AssetID of the booster pack in question
- `callback` - A function to be called when the request completes
    - `err` - An `Error` object on failure, or `null` on success
    - `res` - An array containing information on the opened cards.

**v or later is required to use this method**

Open a booster pack.