### PR TITLE
add cancelAllConfirmations method

### DIFF
--- a/components/confirmations.js
+++ b/components/confirmations.js
@@ -242,6 +242,39 @@ SteamCommunity.prototype.acceptAllConfirmations = function(time, confKey, allowK
 	});
 };
 
+/**
+ * Send a single request to Steam to cancel all outstanding confirmations (after loading the list). If one fails, the
+ * entire request will fail and there will be no way to know which failed without loading the list again.
+ * @param {number} time
+ * @param {string} confKey
+ * @param {string} cancelKey
+ * @param {function} callback
+ */
+SteamCommunity.prototype.cancelAllConfirmations = function(time, confKey, cancelKey, callback) {
+	var self = this;
+
+	this.getConfirmations(time, confKey, function(err, confs) {
+		if (err) {
+			callback(err);
+			return;
+		}
+
+		if (confs.length == 0) {
+			callback(null, []);
+			return;
+		}
+
+		self.respondToConfirmation(confs.map(function(conf) { return conf.id; }), confs.map(function(conf) { return conf.key; }), time, cancelKey, false, function(err) {
+			if (err) {
+				callback(err);
+				return;
+			}
+
+			callback(err, confs);
+		});
+	});
+};
+
 function request(community, url, key, time, tag, params, json, callback) {
 	if (!community.steamID) {
 		throw new Error("Must be logged in before trying to do anything with confirmations");


### PR DESCRIPTION
**cancelAllConfirmations(time, confKey, cancelKey, callback)**
- time - Should be a unix timestamp
- confKey - Should be a base64-encoded key for the "conf" tag, generated using the supplied time
- cancelKey - Should be a base64-encoded key for the "cancel" tag, generated using the supplied time
- callback - Called when the request completes
- err - An Error object on failure, or null on success
- confs - An array of the confirmations that were just cancelled. May be empty if there were no pending confirmations.

Cancel all outstanding confirmations on your account all at once.