### PR TITLE
Fix parentalUnlock

### DIFF
--- a/index.js
+++ b/index.js
@@ -323,11 +323,13 @@ function generateSessionID() {
 
 SteamCommunity.prototype.parentalUnlock = function(pin, callback) {
 	var self = this;
+	var sessionID = self.getSessionID();
 
 	this.httpRequestPost("https://steamcommunity.com/parental/ajaxunlock", {
 		"json": true,
 		"form": {
-			"pin": pin
+			"pin": pin,
+			"sessionid": sessionID
 		}
 	}, function(err, response, body) {
 		if(!callback) {


### PR DESCRIPTION
Hi @DoctorMcKay,
Recently I found that Steam `parental/ajaxunlock` request needs `sessionid` field in the form body so I create this PR to fix it