### PR TITLE
Sack pack/unpack

### DIFF
--- a/components/market.js
+++ b/components/market.js
@@ -146,6 +146,56 @@ SteamCommunity.prototype.openBoosterPack = function(appid, assetid, callback) {
 	})
 };
 
+SteamCommunity.prototype._sackExchanger = function(assetid, amount, unpacking, callback) {
+	this._myProfile({
+		"endpoint": "ajaxexchangegoo/",
+		"json": true,
+		"checkHttpError": false
+	}, {
+		"appid": 753,
+		"assetid": assetid,
+		"sessionid": this.getSessionID(),
+		"goo_denomination_in": unpacking ? 1000 : 1,
+		"goo_amount_in": unpacking ? amount : amount * 1000,
+		"goo_denomination_out": unpacking ? 1 : 1000,
+		"goo_amount_out_expected": unpacking ? 1000 * amount : amount
+	}, (err, res, body) => {
+		if (err) {
+			callback(err);
+			return;
+		}
+
+		if (body.success && body.success != SteamCommunity.EResult.OK) {
+			let err = new Error(body.message || SteamCommunity.EResult[body.success]);
+			err.eresult = err.code = body.success;
+			callback(err);
+			return;
+		}
+
+		callback(null);
+	})
+};
+
+/**
+ * Pack sack(s) of gems.
+ * @param {int|string} assetid
+ * @param {int} sacks
+ * @param {function} callback
+ */
+SteamCommunity.prototype.packSack = function(assetid, sacks, callback) {
+	this._sackExchanger(assetid, sacks, false, callback);
+};
+
+/**
+ * Unpack sack(s) of gems.
+ * @param {int|string} assetid
+ * @param {int} sacks
+ * @param {function} callback
+ */
+SteamCommunity.prototype.unpackSack = function(assetid, sacks, callback) {
+	this._sackExchanger(assetid, sacks, true, callback);
+};
+
 /**
  * Get details about a gift in your inventory.
  * @param {string} giftID

--- a/components/market.js
+++ b/components/market.js
@@ -106,7 +106,7 @@ SteamCommunity.prototype.turnItemIntoGems = function(appid, assetid, expectedGem
 		}
 
 		callback(null, {"gemsReceived": parseInt(body['goo_value_received '], 10), "totalGems": parseInt(body.goo_value_total, 10)});
-	})
+	});
 };
 
 /**
@@ -143,7 +143,7 @@ SteamCommunity.prototype.openBoosterPack = function(appid, assetid, callback) {
 		}
 
 		callback(null, body.rgItems);
-	})
+	});
 };
 
 SteamCommunity.prototype._sackExchanger = function(assetid, amount, unpacking, callback) {
@@ -173,7 +173,7 @@ SteamCommunity.prototype._sackExchanger = function(assetid, amount, unpacking, c
 		}
 
 		callback(null);
-	})
+	});
 };
 
 /**


### PR DESCRIPTION
This adds gem sack packing and unpacking functionality. I'm not sure if I picked the best names for the functions though, they are named: `packSack` and `unpackSack`. I also added a common `_sackExchanger` function since they both use the same call. Hope this implementation is OK, but I can understand if you have feedback.

**packSack**
```js
community.packSack("7644419617", 2, (err) => {
	console.log("err", err);
});
```
Where the first param is the assetid of the gems and 2 is the number of sacks we will be getting.

**unpackSack**
```js
community.unpackSack("14878056558", 2, (err) => {
	console.log("err", err);
});
```

Where first param is the assetid of the sack and 2 is the number of sacks we will be converting back into gems.

Also if this gets accepted and you get around to updating the wiki, you previously didn't add `openBoosterPack` to the wiki: https://github.com/DoctorMcKay/node-steamcommunity/issues/256 