### PR TITLE
Added getFriendsList

### DIFF
--- a/resources/EFriendRelationship.js
+++ b/resources/EFriendRelationship.js
@@ -1,0 +1,23 @@
+/**
+ * @enum EFriendRelationship
+ */
+ module.exports = {
+	"None": 0,
+	"Blocked": 1,
+	"RequestRecipient": 2,
+	"Friend": 3,
+	"RequestInitiator": 4,
+	"Ignored": 5,
+	"IgnoredFriend": 6,
+	"SuggestedFriend": 7, // removed "was used by the original implementation of the facebook linking feature; but now unused."
+
+	// Value-to-name mapping for convenience
+	"0": "None",
+	"1": "Blocked",
+	"2": "RequestRecipient",
+	"3": "Friend",
+	"4": "RequestInitiator",
+	"5": "Ignored",
+	"6": "IgnoredFriend",
+	"7": "SuggestedFriend",
+};


### PR DESCRIPTION
This will return a friend list similar to https://github.com/DoctorMcKay/node-steam-user#myfriends. 
This will also include blocked/ignored users, so this PR resolves https://github.com/DoctorMcKay/node-steamcommunity/issues/255 and making https://github.com/DoctorMcKay/node-steamcommunity/pull/266 redundant. 