### PR TITLE
Re-enable primaryGroup profile setting

### DIFF
--- a/classes/CSteamSharedfile.js
+++ b/classes/CSteamSharedfile.js
@@ -64,14 +64,6 @@ SteamCommunity.prototype.getSteamSharedfile = function(sid, callback) {
             sharedfile.appID = Number($("#ShareItemBtn").attr()["onclick"].replace(`ShowSharePublishedFilePopup( '${sid}', '`, "").replace("' );", ""))
 
 
-            // Find owner profile link, convert to steamID64 using steamIdResolver lib and create a SteamID object
-            let ownerHref = $(".friendBlockLinkOverlay").attr()["href"];
-
-            steamIdResolver.customUrlToSteamID64(ownerHref, (err, steamID64) => { // Note: Callback will be called before this is done, takes around 1 sec to populate
-                if (!err) sharedfile.owner = new SteamID(steamID64);
-            });
-
-
             // Find fileSize if not guide
             sharedfile.fileSize = detailsStatsObj["File Size"] || null; // TODO: Convert to bytes? It seems like to always be MB but no guarantee
 
@@ -124,7 +116,15 @@ SteamCommunity.prototype.getSteamSharedfile = function(sid, callback) {
             if (breadcrumb.includes("Guide"))      sharedfile.type = ESharedfileType.Guide;
 
 
-            callback(null, new CSteamSharedfile(this, sharedfile));
+            // Find owner profile link, convert to steamID64 using steamIdResolver lib and create a SteamID object
+            let ownerHref = $(".friendBlockLinkOverlay").attr()["href"];
+
+            steamIdResolver.customUrlToSteamID64(ownerHref, (err, steamID64) => { // This request takes <1 sec
+                if (!err) sharedfile.owner = new SteamID(steamID64);
+
+                // Make callback when ID was resolved as otherwise owner will always be null
+                callback(null, new CSteamSharedfile(this, sharedfile));
+            });
 
         } catch (err) {
             callback(err, null);
@@ -156,7 +156,7 @@ function CSteamSharedfile(community, data) {
  * @param {function} callback - Takes only an Error object/null as the first argument
  */
 CSteamSharedfile.prototype.deleteComment = function(cid, callback) {
-    this._community.deleteSharedfileComment(this.userID, this.sid, cid, callback);
+    this._community.deleteSharedfileComment(this.userID, this.id, cid, callback);
 };
 
 /**
@@ -164,7 +164,7 @@ CSteamSharedfile.prototype.deleteComment = function(cid, callback) {
  * @param {function} callback - Takes only an Error object/null as the first argument
  */
 CSteamSharedfile.prototype.favorite = function(callback) {
-    this._community.favoriteSharedfile(this.sid, this.appID, callback);
+    this._community.favoriteSharedfile(this.id, this.appID, callback);
 };
 
 /**
@@ -173,7 +173,7 @@ CSteamSharedfile.prototype.favorite = function(callback) {
  * @param {function} callback - Takes only an Error object/null as the first argument
  */
 CSteamSharedfile.prototype.comment = function(message, callback) {
-    this._community.postSharedfileComment(this.owner, this.sid, message, callback);
+    this._community.postSharedfileComment(this.owner, this.id, message, callback);
 };
 
 /**
@@ -181,7 +181,7 @@ CSteamSharedfile.prototype.comment = function(message, callback) {
  * @param {function} callback - Takes only an Error object/null as the first argument
  */
 CSteamSharedfile.prototype.subscribe = function(callback) {
-    this._community.subscribeSharedfileComments(this.owner, this.sid, callback);
+    this._community.subscribeSharedfileComments(this.owner, this.id, callback);
 };
 
 /**
@@ -189,7 +189,7 @@ CSteamSharedfile.prototype.subscribe = function(callback) {
  * @param {function} callback - Takes only an Error object/null as the first argument
  */
 CSteamSharedfile.prototype.unfavorite = function(callback) {
-    this._community.unfavoriteSharedfile(this.sid, this.appID, callback);
+    this._community.unfavoriteSharedfile(this.id, this.appID, callback);
 };
 
 /**
@@ -197,7 +197,7 @@ CSteamSharedfile.prototype.unfavorite = function(callback) {
  * @param {function} callback - Takes only an Error object/null as the first argument
  */
 CSteamSharedfile.prototype.unsubscribe = function(callback) {
-    this._community.unsubscribeSharedfileComments(this.owner, this.sid, callback);
+    this._community.unsubscribeSharedfileComments(this.owner, this.id, callback);
 };
 
 /**
@@ -205,7 +205,7 @@ CSteamSharedfile.prototype.unsubscribe = function(callback) {
  * @param {function} callback - Takes only an Error object/null as the first argument
  */
 CSteamSharedfile.prototype.voteDown = function(callback) {
-    this._community.voteDownSharedfile(this.sid, callback);
+    this._community.voteDownSharedfile(this.id, callback);
 };
 
 /**
@@ -213,5 +213,5 @@ CSteamSharedfile.prototype.voteDown = function(callback) {
  * @param {function} callback - Takes only an Error object/null as the first argument
  */
 CSteamSharedfile.prototype.voteUp = function(callback) {
-    this._community.voteUpSharedfile(this.sid, callback);
+    this._community.voteUpSharedfile(this.id, callback);
 };

--- a/classes/CSteamSharedfile.js
+++ b/classes/CSteamSharedfile.js
@@ -1,0 +1,152 @@
+const Cheerio = require("cheerio");
+const SteamID = require("steamid");
+const SteamCommunity  = require("../index.js");
+const steamIdResolver = require("steamid-resolver");
+const ESharedfileType = require("../resources/ESharedfileType.js");
+
+
+/**
+ * Scrape a sharedfile's DOM to get all available information
+ * @param {String} sid - ID of the sharedfile
+ * @param {function} callback -  First argument is null/Error, second is object containing all available information
+ */
+SteamCommunity.prototype.getSteamSharedfile = function(sid, callback) {
+    // Construct object holding all the data we can scrape
+    let sharedfile = {
+        id: sid,
+        type: null,
+        appID: null,
+        owner: null,
+        fileSize: null,
+        postDate: null,
+        resolution: null,
+        uniqueVisitorsCount: null,
+        favoritesCount: null,
+        upvoteCount: null
+    }
+
+
+    // Get DOM of sharedfile
+    this.httpRequestGet(`https://steamcommunity.com/sharedfiles/filedetails/?id=${sid}`, (err, res, body) => {
+        try {
+
+            /* --------------------- Preprocess output --------------------- */
+
+            // Load output into cheerio to make parsing easier
+            let $ = Cheerio.load(body);
+
+            // Dynamically map detailsStatsContainerLeft to detailsStatsContainerRight in an object to make readout easier. It holds size, post date and resolution.
+            let detailsStatsObj = {};
+            let detailsLeft     = $(".detailsStatsContainerLeft").children();
+            let detailsRight    = $(".detailsStatsContainerRight").children();
+
+            Object.keys(detailsLeft).forEach((e) => { // Dynamically get all details. Don't hardcore so that this also works for guides.
+                if (isNaN(e)) return; // Ignore invalid entries
+
+                detailsStatsObj[detailsLeft[e].children[0].data.trim()] = detailsRight[e].children[0].data;
+            });
+
+            // Dynamically map stats_table descriptions to values. This holds Unique Visitors and Current Favorites
+            let statsTableObj = {};
+            let statsTable = $(".stats_table").children();
+
+            Object.keys(statsTable).forEach((e, i) => {
+                if (isNaN(e)) return; // Ignore invalid entries
+
+                // Value description is at index 3, value data at index 1
+                statsTableObj[statsTable[e].children[3].children[0].data] = statsTable[e].children[1].children[0].data.replace(/,/g, ""); // Remove commas from 1k+ values
+            });
+
+
+            /* --------------------- Find and map values --------------------- */
+
+            // Find appID in share button onclick event
+            sharedfile.appID = Number($("#ShareItemBtn").attr()["onclick"].replace(`ShowSharePublishedFilePopup( '${sid}', '`, "").replace("' );", ""))
+
+
+            // Find owner profile link, convert to steamID64 using steamIdResolver lib and create a SteamID object
+            let ownerHref = $(".friendBlockLinkOverlay").attr()["href"];
+
+            steamIdResolver.customUrlToSteamID64(ownerHref, (err, steamID64) => { // Note: Callback will be called before this is done, takes around 1 sec to populate
+                if (!err) sharedfile.owner = new SteamID(steamID64);
+            });
+
+
+            // Find fileSize if not guide
+            sharedfile.fileSize = detailsStatsObj["File Size"] || null; // TODO: Convert to bytes? It seems like to always be MB but no guarantee
+
+            // Find postDate and convert to timestamp (Warning: Will get ugly)
+            let posted = detailsStatsObj["Posted"].replace(/,|@/g, "").split(" "); // Remove comma behind month and @, the date & time separator. Split by space to get: Day, Month, Year (if not current) and time
+            let months = { "Jan": "01", "Feb": "02", "Mar": "03", "Apr": "04", "May": "05", "Jun": "06", "Jul": "07", "Aug": "08", "Sep": "09", "Oct": "10", "Nov": "11", "Dec": "12" }; // Map all month abbreviations
+
+            if (posted[0].split(":")[0].length == 1) posted[0] = "0" + posted[0]; // Add zero if day is <10 to have a fixed length 
+
+            posted[1] = months[posted[1]]; // Replace month abbreviation with corresponding Number
+
+            if (!posted[2]) posted[2] = new Date().getUTCFullYear().toString(); // Add current year if Steam did not list one
+                else posted.splice(3, 1); // ...otherwise remove element 3 as it will be an empty String
+
+            // Convert AM/PM time to 24h format - Credit: https://stackoverflow.com/a/40197728 (Modified)
+            if (posted[3].split(":")[0].length == 1) posted[3] = "0" + posted[3]; // Add zero if hour is <10 to have a fixed length 
+
+            let time     = posted[3].substring(0, 5);
+            let modifier = posted[3].substring(5, 7);
+            let [hours, minutes] = time.split(":");
+            
+            if (hours === "12") hours = "00";
+            if (modifier === "pm") hours = parseInt(hours, 10) + 12;
+
+            sharedfile.postDate = Date.parse(`${posted[2]}-${posted[1]}-${posted[0]}T${hours}:${minutes}:00.000Z`); // Construct Date String and parse it to get Unix timestamp
+
+
+            // Find resolution if artwork or screenshot
+            sharedfile.resolution = detailsStatsObj["Size"] || null;
+
+
+            // Find uniqueVisitorsCount. We can't use ' || null' here as Number("0") casts to false
+            if (statsTableObj["Unique Visitors"]) sharedfile.uniqueVisitorsCount = Number(statsTableObj["Unique Visitors"]);
+
+
+            // Find favoritesCount. We can't use ' || null' here as Number("0") casts to false
+            if (statsTableObj["Current Favorites"]) sharedfile.favoritesCount = Number(statsTableObj["Current Favorites"]);
+
+
+            // Find upvoteCount. We can't use ' || null' here as Number("0") casts to false
+            let upvoteCount = $("#VotesUpCountContainer > #VotesUpCount").text();
+            if (upvoteCount) sharedfile.upvoteCount = Number(upvoteCount);
+
+
+            // Determine type by looking at the second breadcrumb. Find the first separator as it has a unique name and go to the next element which holds our value of interest
+            let breadcrumb = $(".breadcrumbs > .breadcrumb_separator").next().get(0).children[0].data || "";
+            
+            if (breadcrumb.includes("Screenshot")) sharedfile.type = ESharedfileType.Screenshot;
+            if (breadcrumb.includes("Artwork"))    sharedfile.type = ESharedfileType.Artwork;
+            if (breadcrumb.includes("Guide"))      sharedfile.type = ESharedfileType.Guide;
+
+
+            callback(null, new CSteamSharedfile(this, sharedfile));
+
+        } catch (err) {
+            callback(err, null);
+        }
+    });
+}
+
+
+function CSteamSharedfile(community, data) {
+    this._community = community;
+
+    // Clone all the data we recieved
+    Object.assign(this, data); // TODO: This is cleaner but might break IntelliSense
+
+    /* this.id = data.id;
+    this.type = data.type;
+    this.appID = data.appID;
+    this.owner = data.owner;
+    this.fileSize = data.fileSize;
+    this.postDate = data.postDate;
+    this.resolution = data.resolution;
+    this.uniqueVisitorsCount = data.uniqueVisitorsCount;
+    this.favoritesCount = data.favoritesCount;
+    this.upvoteCount = data.upvoteCount; */
+}

--- a/classes/CSteamSharedfile.js
+++ b/classes/CSteamSharedfile.js
@@ -129,9 +129,8 @@ SteamCommunity.prototype.getSteamSharedfile = function(sid, callback) {
         } catch (err) {
             callback(err, null);
         }
-    });
-}
-
+    }, "steamcommunity");
+};
 
 function CSteamSharedfile(community, data) {
     this._community = community;

--- a/classes/CSteamSharedfile.js
+++ b/classes/CSteamSharedfile.js
@@ -149,3 +149,69 @@ function CSteamSharedfile(community, data) {
     this.favoritesCount = data.favoritesCount;
     this.upvoteCount = data.upvoteCount; */
 }
+
+/**
+ * Deletes a comment from this sharedfile's comment section
+ * @param {String} cid - ID of the comment to delete
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+CSteamSharedfile.prototype.deleteComment = function(cid, callback) {
+    this._community.deleteSharedfileComment(this.userID, this.sid, cid, callback);
+};
+
+/**
+ * Favorites this sharedfile
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+CSteamSharedfile.prototype.favorite = function(callback) {
+    this._community.favoriteSharedfile(this.sid, this.appID, callback);
+};
+
+/**
+ * Posts a comment to this sharedfile
+ * @param {String} message - Content of the comment to post
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+CSteamSharedfile.prototype.comment = function(message, callback) {
+    this._community.postSharedfileComment(this.owner, this.sid, message, callback);
+};
+
+/**
+ * Subscribes to this sharedfile's comment section. Note: Checkbox on webpage does not update
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+CSteamSharedfile.prototype.subscribe = function(callback) {
+    this._community.subscribeSharedfileComments(this.owner, this.sid, callback);
+};
+
+/**
+ * Unfavorites this sharedfile
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+CSteamSharedfile.prototype.unfavorite = function(callback) {
+    this._community.unfavoriteSharedfile(this.sid, this.appID, callback);
+};
+
+/**
+ * Unsubscribes from this sharedfile's comment section. Note: Checkbox on webpage does not update
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+CSteamSharedfile.prototype.unsubscribe = function(callback) {
+    this._community.unsubscribeSharedfileComments(this.owner, this.sid, callback);
+};
+
+/**
+ * Downvotes this sharedfile
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+CSteamSharedfile.prototype.voteDown = function(callback) {
+    this._community.voteDownSharedfile(this.sid, callback);
+};
+
+/**
+ * Upvotes this sharedfile
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+CSteamSharedfile.prototype.voteUp = function(callback) {
+    this._community.voteUpSharedfile(this.sid, callback);
+};

--- a/components/profile.js
+++ b/components/profile.js
@@ -106,6 +106,15 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 					values.customURL = settings[i];
 					break;
 
+				case 'primaryGroup':
+					if(typeof settings[i] === 'object' && settings[i].getSteamID64) {
+						values.primary_group_steamid = settings[i].getSteamID64();
+					} else {
+						values.primary_group_steamid = new SteamID(settings[i]).getSteamID64();
+					}
+
+					break;
+
 				// These don't work right now
 				/*
 				case 'background':
@@ -116,15 +125,6 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 				case 'featuredBadge':
 					// Currently, game badges aren't supported
 					values.favorite_badge_badgeid = settings[i];
-					break;
-
-				case 'primaryGroup':
-					if(typeof settings[i] === 'object' && settings[i].getSteamID64) {
-						values.primary_group_steamid = settings[i].getSteamID64();
-					} else {
-						values.primary_group_steamid = new SteamID(settings[i]).getSteamID64();
-					}
-
 					break;
 				*/
 				// TODO: profile showcases

--- a/components/sharedfiles.js
+++ b/components/sharedfiles.js
@@ -87,7 +87,7 @@ SteamCommunity.prototype.postSharedfileComment = function(userID, sid, message, 
  * @param {String} sid ID of the sharedfileof
  * @param {function} callback - Takes only an Error object/null as the first argument
  */
-Bot.prototype.subscribeSharedfileComments = function(userID, sid, callback) {
+SteamCommunity.prototype.subscribeSharedfileComments = function(userID, sid, callback) {
     if (typeof userID === "string") {
         userID = new SteamID(userID);
     }
@@ -135,7 +135,7 @@ Bot.prototype.subscribeSharedfileComments = function(userID, sid, callback) {
  * @param {String} sid - ID of the sharedfileof
  * @param {function} callback - Takes only an Error object/null as the first argument
  */
-Bot.prototype.unsubscribeSharedfileComments = function(userID, sid, callback) {
+SteamCommunity.prototype.unsubscribeSharedfileComments = function(userID, sid, callback) {
     if (typeof userID === "string") {
         userID = new SteamID(userID);
     }

--- a/components/sharedfiles.js
+++ b/components/sharedfiles.js
@@ -58,3 +58,45 @@ SteamCommunity.prototype.postSharedfileComment = function(userID, sid, message, 
         callback(null || err);
     }, "steamcommunity");
 };
+
+/**
+ * Downvotes a sharedfile
+ * @param {String} sid - ID of the sharedfile
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+SteamCommunity.prototype.voteDownSharedfile = function(sid, callback) {
+    this.httpRequestPost({
+        "uri": "https://steamcommunity.com/sharedfiles/votedown",
+        "form": {
+            "id": sid,
+            "sessionid": this.getSessionID()
+        }
+    }, function(err, response, body) {
+        if (!callback) {
+            return;
+        }
+
+        callback(null || err);
+    }, "steamcommunity");
+};
+
+/**
+ * Upvotes a sharedfile
+ * @param {String} sid - ID of the sharedfile
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+SteamCommunity.prototype.voteUpSharedfile = function(sid, callback) {
+    this.httpRequestPost({
+        "uri": "https://steamcommunity.com/sharedfiles/voteup",
+        "form": {
+            "id": sid,
+            "sessionid": this.getSessionID()
+        }
+    }, function(err, response, body) {
+        if (!callback) {
+            return;
+        }
+
+        callback(null || err);
+    }, "steamcommunity");
+};

--- a/components/sharedfiles.js
+++ b/components/sharedfiles.js
@@ -32,6 +32,28 @@ SteamCommunity.prototype.deleteSharedfileComment = function(userID, sid, cid, ca
 };
 
 /**
+ * Favorites a sharedfile
+ * @param {String} sid - ID of the sharedfile
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+/* SteamCommunity.prototype.favoriteSharedfile = function(sid, callback) {
+    this.httpRequestPost({
+        "uri": "https://steamcommunity.com/sharedfiles/favorite",
+        "form": {
+            "id": sid,
+            "appid": , // TODO: How to get appid the sharedfile is associated to?
+            "sessionid": this.getSessionID()
+        }
+    }, function(err, response, body) {
+        if (!callback) {
+            return;
+        }
+
+        callback(null || err);
+    }, "steamcommunity");
+}; */
+
+/**
  * Posts a comment to a sharedfile
  * @param {SteamID | String} userID - ID of the user associated to this sharedfile
  * @param {String} sid - ID of the sharedfile
@@ -84,6 +106,28 @@ Bot.prototype.subscribeSharedfileComments = function(userID, sid, callback) {
         callback(null || err);
     }, "steamcommunity");
 };
+
+/**
+ * Unfavorites a sharedfile
+ * @param {String} sid - ID of the sharedfile
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+/* SteamCommunity.prototype.unfavoriteSharedfile = function(sid, callback) {
+    this.httpRequestPost({
+        "uri": "https://steamcommunity.com/sharedfiles/unfavorite",
+        "form": {
+            "id": sid,
+            "appid": , // TODO: How to get appid the sharedfile is associated to?
+            "sessionid": this.getSessionID()
+        }
+    }, function(err, response, body) {
+        if (!callback) {
+            return;
+        }
+
+        callback(null || err);
+    }, "steamcommunity");
+}; */
 
 /**
  * Unsubscribes from a sharedfile's comment section. Note: Checkbox on webpage does not update

--- a/components/sharedfiles.js
+++ b/components/sharedfiles.js
@@ -60,6 +60,58 @@ SteamCommunity.prototype.postSharedfileComment = function(userID, sid, message, 
 };
 
 /**
+ * Subscribes to a sharedfile's comment section. Note: Checkbox on webpage does not update
+ * @param {SteamID | String} userID ID of the user associated to this sharedfile
+ * @param {String} sid ID of the sharedfileof
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+Bot.prototype.subscribeSharedfileComments = function(userID, sid, callback) {
+    if (typeof userID === "string") {
+        userID = new SteamID(userID);
+    }
+
+    this.httpRequestPost({
+        "uri": `https://steamcommunity.com/comment/PublishedFile_Public/subscribe/${userID.toString()}/${sid}/`,
+        "form": {
+            "count": 10,
+            "sessionid": this.getSessionID()
+        }
+    }, function(err, response, body) { // eslint-disable-line
+        if (!callback) {
+            return;
+        }
+
+        callback(null || err);
+    }, "steamcommunity");
+};
+
+/**
+ * Unsubscribes from a sharedfile's comment section. Note: Checkbox on webpage does not update
+ * @param {SteamID | String} userID - ID of the user associated to this sharedfile
+ * @param {String} sid - ID of the sharedfileof
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+Bot.prototype.unsubscribeSharedfileComments = function(userID, sid, callback) {
+    if (typeof userID === "string") {
+        userID = new SteamID(userID);
+    }
+
+    this.httpRequestPost({
+        "uri": `https://steamcommunity.com/comment/PublishedFile_Public/unsubscribe/${userID.toString()}/${sid}/`,
+        "form": {
+            "count": 10,
+            "sessionid": this.getSessionID()
+        }
+    }, function(err, response, body) { // eslint-disable-line
+        if (!callback) {
+            return;
+        }
+
+        callback(null || err);
+    }, "steamcommunity");
+};
+
+/**
  * Downvotes a sharedfile
  * @param {String} sid - ID of the sharedfile
  * @param {function} callback - Takes only an Error object/null as the first argument

--- a/components/sharedfiles.js
+++ b/components/sharedfiles.js
@@ -34,14 +34,15 @@ SteamCommunity.prototype.deleteSharedfileComment = function(userID, sid, cid, ca
 /**
  * Favorites a sharedfile
  * @param {String} sid - ID of the sharedfile
+ * @param {String} appid - ID of the app associated to this sharedfile
  * @param {function} callback - Takes only an Error object/null as the first argument
  */
-/* SteamCommunity.prototype.favoriteSharedfile = function(sid, callback) {
+SteamCommunity.prototype.favoriteSharedfile = function(sid, appid, callback) {
     this.httpRequestPost({
         "uri": "https://steamcommunity.com/sharedfiles/favorite",
         "form": {
             "id": sid,
-            "appid": , // TODO: How to get appid the sharedfile is associated to?
+            "appid": appid,
             "sessionid": this.getSessionID()
         }
     }, function(err, response, body) {
@@ -51,7 +52,7 @@ SteamCommunity.prototype.deleteSharedfileComment = function(userID, sid, cid, ca
 
         callback(null || err);
     }, "steamcommunity");
-}; */
+};
 
 /**
  * Posts a comment to a sharedfile
@@ -110,14 +111,15 @@ SteamCommunity.prototype.subscribeSharedfileComments = function(userID, sid, cal
 /**
  * Unfavorites a sharedfile
  * @param {String} sid - ID of the sharedfile
+ * @param {String} appid - ID of the app associated to this sharedfile
  * @param {function} callback - Takes only an Error object/null as the first argument
  */
-/* SteamCommunity.prototype.unfavoriteSharedfile = function(sid, callback) {
+SteamCommunity.prototype.unfavoriteSharedfile = function(sid, appid, callback) {
     this.httpRequestPost({
         "uri": "https://steamcommunity.com/sharedfiles/unfavorite",
         "form": {
             "id": sid,
-            "appid": , // TODO: How to get appid the sharedfile is associated to?
+            "appid": appid,
             "sessionid": this.getSessionID()
         }
     }, function(err, response, body) {
@@ -127,7 +129,7 @@ SteamCommunity.prototype.subscribeSharedfileComments = function(userID, sid, cal
 
         callback(null || err);
     }, "steamcommunity");
-}; */
+};
 
 /**
  * Unsubscribes from a sharedfile's comment section. Note: Checkbox on webpage does not update

--- a/components/sharedfiles.js
+++ b/components/sharedfiles.js
@@ -1,0 +1,60 @@
+var SteamCommunity = require('../index.js');
+var SteamID = require('steamid');
+
+// Note: a CSteamSharedfile class does not exist because we can't get data using the "normal" xml way to fill a CSteamSharedfile object
+
+/**
+ * Deletes a comment from a sharedfile's comment section
+ * @param {SteamID | String} userID - ID of the user associated to this sharedfile
+ * @param {String} sid - ID of the sharedfile
+ * @param {String} cid - ID of the comment to delete
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+SteamCommunity.prototype.deleteSharedfileComment = function(userID, sid, cid, callback) {
+    if (typeof userID === "string") {
+        userID = new SteamID(userID);
+    }
+
+    this.httpRequestPost({
+        "uri": `https://steamcommunity.com/comment/PublishedFile_Public/delete/${userID.toString()}/${sid}/`,
+        "form": {
+            "gidcomment": cid,
+            "count": 10,
+            "sessionid": this.getSessionID()
+        }
+    }, function(err, response, body) {
+        if (!callback) {
+            return;
+        }
+
+        callback(null || err);
+    }, "steamcommunity");
+};
+
+/**
+ * Posts a comment to a sharedfile
+ * @param {SteamID | String} userID - ID of the user associated to this sharedfile
+ * @param {String} sid - ID of the sharedfile
+ * @param {String} message - Content of the comment to post
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+SteamCommunity.prototype.postSharedfileComment = function(userID, sid, message, callback) {
+    if (typeof userID === "string") {
+        userID = new SteamID(userID);
+    }
+
+    this.httpRequestPost({
+        "uri": `https://steamcommunity.com/comment/PublishedFile_Public/post/${userID.toString()}/${sid}/`,
+        "form": {
+            "comment": message,
+            "count": 10,
+            "sessionid": this.getSessionID()
+        }
+    }, function(err, response, body) {
+        if (!callback) {
+            return;
+        }
+
+        callback(null || err);
+    }, "steamcommunity");
+};

--- a/components/sharedfiles.js
+++ b/components/sharedfiles.js
@@ -1,7 +1,6 @@
 var SteamCommunity = require('../index.js');
 var SteamID = require('steamid');
 
-// Note: a CSteamSharedfile class does not exist because we can't get data using the "normal" xml way to fill a CSteamSharedfile object
 
 /**
  * Deletes a comment from a sharedfile's comment section
@@ -85,7 +84,7 @@ SteamCommunity.prototype.postSharedfileComment = function(userID, sid, message, 
 /**
  * Subscribes to a sharedfile's comment section. Note: Checkbox on webpage does not update
  * @param {SteamID | String} userID ID of the user associated to this sharedfile
- * @param {String} sid ID of the sharedfileof
+ * @param {String} sid ID of the sharedfile
  * @param {function} callback - Takes only an Error object/null as the first argument
  */
 SteamCommunity.prototype.subscribeSharedfileComments = function(userID, sid, callback) {
@@ -134,7 +133,7 @@ SteamCommunity.prototype.unfavoriteSharedfile = function(sid, appid, callback) {
 /**
  * Unsubscribes from a sharedfile's comment section. Note: Checkbox on webpage does not update
  * @param {SteamID | String} userID - ID of the user associated to this sharedfile
- * @param {String} sid - ID of the sharedfileof
+ * @param {String} sid - ID of the sharedfile
  * @param {function} callback - Takes only an Error object/null as the first argument
  */
 SteamCommunity.prototype.unsubscribeSharedfileComments = function(userID, sid, callback) {

--- a/index.js
+++ b/index.js
@@ -573,6 +573,7 @@ require('./components/profile.js');
 require('./components/market.js');
 require('./components/groups.js');
 require('./components/users.js');
+require("./components/sharedfiles.js");
 require('./components/inventoryhistory.js');
 require('./components/webapi.js');
 require('./components/twofactor.js');

--- a/index.js
+++ b/index.js
@@ -573,7 +573,7 @@ require('./components/profile.js');
 require('./components/market.js');
 require('./components/groups.js');
 require('./components/users.js');
-require("./components/sharedfiles.js");
+require('./components/sharedfiles.js');
 require('./components/inventoryhistory.js');
 require('./components/webapi.js');
 require('./components/twofactor.js');
@@ -582,6 +582,7 @@ require('./components/help.js');
 require('./classes/CMarketItem.js');
 require('./classes/CMarketSearchResult.js');
 require('./classes/CSteamGroup.js');
+require('./classes/CSteamSharedfile.js');
 require('./classes/CSteamUser.js');
 
 /**

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"request": "^2.88.0",
 		"steam-totp": "^1.5.0",
 		"steamid": "^1.1.3",
+		"steamid-resolver": "^1.2.3",
 		"xml2js": "^0.4.22"
 	},
 	"engines": {

--- a/resources/ESharedfileType.js
+++ b/resources/ESharedfileType.js
@@ -1,0 +1,13 @@
+/**
+ * @enum ESharedfileType
+ */
+module.exports = {
+    "Screenshot": 0,
+    "Artwork": 1,
+    "Guide": 2,
+
+    // Value-to-name mapping for convenience
+    "0": "Screenshot",
+    "1": "Artwork",
+    "2": "Guide"
+};


### PR DESCRIPTION
Hey!  
The primaryGroup setting in the `editProfile()` function does seem to work again so I decided to open a PR that enables the code block again.  

I've tested the function with a limited and an unlimited account. The limited acc has E-Mail steam guard, the unlimited acc is secured with mobile steam guard.  
  
I called the function like this from the `webSession` event to make sure cookies were set:  
```
const SteamID = require("steamid")

community.editProfile({ //community was set previously as a new SteamCommunity object
    primaryGroup: new SteamID("my_groupID64")
}, (err) => {
    if (err) console.log(err);
})
```
  
&nbsp;

This successfully updated my primaryGroup setting.  
I also tested the other two disabled settings (`background` & `featuredBadge`) but was unable to get them to work as well :(