### PR TITLE
Fix Not Logged In

### DIFF
--- a/components/http.js
+++ b/components/http.js
@@ -124,7 +124,7 @@ SteamCommunity.prototype._checkCommunityError = function(html, callback) {
 		return err;
 	}
 
-	if (typeof html === 'string' && html.indexOf('g_steamID = false;') > -1 && html.indexOf('<div class="login_title">Sign In</div>') > -1) {
+	if (typeof html === 'string' && html.indexOf('g_steamID = false;') > -1 && html.indexOf('<title>Sign In</title>') > -1) {
 		err = new Error("Not Logged In");
 		callback(err);
 		this._notifySessionExpired(err);


### PR DESCRIPTION
Steam recently changed their login pages. This change should correctly identify the login state.