### PR TITLE
Fix: New rate limit rule from steam

### DIFF
--- a/components/users.js
+++ b/components/users.js
@@ -526,7 +526,7 @@ SteamCommunity.prototype.getUserInventoryContents = function(userID, appID, cont
 			},
 			"qs": {
 				"l": language, // Default language
-				"count": 5000, // Max items per 'page'
+				"count": 2000, // Max items per 'page'
 				"start_assetid": start
 			},
 			"json": true


### PR DESCRIPTION
Hey guys! This PR is just a hotfix for the last steam update.

Steam added a new rule for inventories. 

Requesting with a `count` higher than 2000 will ban the proxy after four requests. 

All requests made with less than 2001 will have a rate limit of around 60/min per proxy. 