### PR TITLE
Re-enable primaryGroup profile setting

### DIFF
--- a/components/profile.js
+++ b/components/profile.js
@@ -106,6 +106,15 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 					values.customURL = settings[i];
 					break;
 
+				case 'primaryGroup':
+					if(typeof settings[i] === 'object' && settings[i].getSteamID64) {
+						values.primary_group_steamid = settings[i].getSteamID64();
+					} else {
+						values.primary_group_steamid = new SteamID(settings[i]).getSteamID64();
+					}
+
+					break;
+
 				// These don't work right now
 				/*
 				case 'background':
@@ -116,15 +125,6 @@ SteamCommunity.prototype.editProfile = function(settings, callback) {
 				case 'featuredBadge':
 					// Currently, game badges aren't supported
 					values.favorite_badge_badgeid = settings[i];
-					break;
-
-				case 'primaryGroup':
-					if(typeof settings[i] === 'object' && settings[i].getSteamID64) {
-						values.primary_group_steamid = settings[i].getSteamID64();
-					} else {
-						values.primary_group_steamid = new SteamID(settings[i]).getSteamID64();
-					}
-
 					break;
 				*/
 				// TODO: profile showcases


### PR DESCRIPTION
Hey!  
The primaryGroup setting in the `editProfile()` function does seem to work again so I decided to open a PR that enables the code block again.  

I've tested the function with a limited and an unlimited account. The limited acc has E-Mail steam guard, the unlimited acc is secured with mobile steam guard.  
  
I called the function like this from the `webSession` event to make sure cookies were set:  
```
const SteamID = require("steamid")

community.editProfile({ //community was set previously as a new SteamCommunity object
    primaryGroup: new SteamID("my_groupID64")
}, (err) => {
    if (err) console.log(err);
})
```
  
&nbsp;

This successfully updated my primaryGroup setting.  
I also tested the other two disabled settings (`background` & `featuredBadge`) but was unable to get them to work as well :(

&nbsp;

Note: This PR was previously #287 from Jun 3, 2022 but I pushed more commits to my master branch. I'm therefore opening this PR to isolate the change from the other commits.