### PR TITLE
Fix resolving vanity for private profiles returning error

### DIFF
--- a/components/helpers.js
+++ b/components/helpers.js
@@ -100,7 +100,16 @@ exports.resolveVanityURL = function(url, callback) {
 			}
 
 			let steamID64 = parsed.profile.steamID64[0];
-			let vanityURL = parsed.profile.customURL[0];
+			
+			let vanityURL;
+
+			if (parsed.profile.customURL) { // Always get customURL from XML if profile is public to support "/profiles/steamID64" urls
+				vanityURL = parsed.profile.customURL[0]
+			} else if (url.includes("steamcommunity.com/id/")) { // Get vanity from url param instead if profile is private as Steam does not include a customURL key for them
+				vanityURL = url.replace("https://steamcommunity.com/id/", "");
+			} else { // If a "/profiles/steamID64" link to a private profile was provided we cannot get the vanity
+				vanityURL = "";
+			}
 
 			callback(null, {"vanityURL": vanityURL, "steamID": steamID64});
 		});


### PR DESCRIPTION
This PR fixes #313 (again)  
Steam does not provide a `customURL` key in the XML data for private profiles which is something I did not expect when working on the previous PR.  

To keep support for providing `/profiles/steamID64` links I have added an if check that only parses the URL param as a fallback option.  
If a `/profiles/steamID64` link was provided to a private profile there is nothing we can do so I am returning an empty string.