### PR TITLE
Fix sharedfiles scraping error when Steam returns non-English page

### DIFF
--- a/classes/CSteamSharedFile.js
+++ b/classes/CSteamSharedFile.js
@@ -31,7 +31,7 @@ SteamCommunity.prototype.getSteamSharedFile = function(sharedFileId, callback) {
 	};
 
 	// Get DOM of sharedfile
-	this.httpRequestGet(`https://steamcommunity.com/sharedfiles/filedetails/?id=${sharedFileId}`, (err, res, body) => {
+	this.httpRequestGet(`https://steamcommunity.com/sharedfiles/filedetails/?id=${sharedFileId}&l=english`, (err, res, body) => { // Request page in english so that the Posted scraping below works
 		try {
 
 			/* --------------------- Preprocess output --------------------- */
@@ -77,9 +77,11 @@ SteamCommunity.prototype.getSteamSharedFile = function(sharedFileId, callback) {
 
 
 			// Find postDate and convert to timestamp
-			let posted = detailsStatsObj["Posted"].trim();
+			let posted = detailsStatsObj["Posted"] || null; // Set to null if "posted" could not be found as Steam translates dates and parsing it below will return a wrong result
 
-			sharedfile.postDate = Helpers.decodeSteamTime(posted);
+			if (posted) {
+				sharedfile.postDate = Helpers.decodeSteamTime(posted.trim()); // Only parse if posted is defined to avoid errors
+			}
 
 
 			// Find resolution if artwork or screenshot


### PR DESCRIPTION
Hey! I've gotten multiple bug reports that scraping the Posted date of a sharedfile can cause an error as Steam can apparently serve a non-English page as response to our request.  
I didn't consider this to be a possibility and didn't encounter this issue while testing, even though my accounts are also not English but German.  

I have added a `&l=english` query parameter to the request and added a fallback to the Posted readout, so that even if it should fail again, no error will be thrown and the Posted value remains `null`.

This fix has been tested and the users who reported it confirmed that the issue did not reoccur afterwards.