### PR TITLE
Add discussions support

### DIFF
--- a/classes/CSteamDiscussion.js
+++ b/classes/CSteamDiscussion.js
@@ -4,7 +4,7 @@ const SteamID = require('steamid');
 const SteamCommunity = require('../index.js');
 const Helpers = require('../components/helpers.js');
 
-const EDiscussionType = require("../resources/EDiscussionType.js");
+const EDiscussionType = require('../resources/EDiscussionType.js');
 
 
 /**
@@ -39,22 +39,22 @@ SteamCommunity.prototype.getSteamDiscussion = function(url, callback) {
 			let $ = Cheerio.load(body);
 
 			// Get breadcrumbs once. Depending on the type of discussion, it either uses "forum" or "group" breadcrumbs
-			let breadcrumbs = $(".forum_breadcrumbs").children();
+			let breadcrumbs = $('.forum_breadcrumbs').children();
 
-			if (breadcrumbs.length == 0) breadcrumbs = $(".group_breadcrumbs").children();
+			if (breadcrumbs.length == 0) breadcrumbs = $('.group_breadcrumbs').children();
 
 
 			/* --------------------- Find and map values --------------------- */
 
 			// Determine type from URL as some checks will deviate, depending on the type
-			if (url.includes("steamcommunity.com/discussions/forum"))     discussion.type = EDiscussionType.Forum;
+			if (url.includes('steamcommunity.com/discussions/forum'))     discussion.type = EDiscussionType.Forum;
 			if (/steamcommunity.com\/app\/.+\/discussions/g.test(url))    discussion.type = EDiscussionType.App;
 			if (/steamcommunity.com\/groups\/.+\/discussions/g.test(url)) discussion.type = EDiscussionType.Group;
 
 
 			// Get appID from breadcrumbs if this discussion is associated to one
 			if (discussion.type == EDiscussionType.App) {
-				let appIdHref = breadcrumbs[0].attribs["href"].split("/");
+				let appIdHref = breadcrumbs[0].attribs.href.split('/');
 
 				discussion.appID = appIdHref[appIdHref.length - 1];
 			}
@@ -64,16 +64,16 @@ SteamCommunity.prototype.getSteamDiscussion = function(url, callback) {
 			let forumIdHref;
 
 			if (discussion.type == EDiscussionType.Group) { // Groups have an extra breadcrumb so we need to shift by 2
-				forumIdHref = breadcrumbs[4].attribs["href"].split("/");
+				forumIdHref = breadcrumbs[4].attribs.href.split('/');
 			} else {
-				forumIdHref = breadcrumbs[2].attribs["href"].split("/");
+				forumIdHref = breadcrumbs[2].attribs.href.split('/');
 			}
 
 			discussion.forumID = forumIdHref[forumIdHref.length - 2];
 
 
 			// Get id, gidforum and topicOwner. The first is used in the URL itself, the other two only in post requests
-			let gids = $(".forum_paging > .forum_paging_controls").attr("id").split("_");
+			let gids = $('.forum_paging > .forum_paging_controls').attr('id').split('_');
 
 			discussion.id = gids[4];
 			discussion.gidforum = gids[3];
@@ -81,33 +81,33 @@ SteamCommunity.prototype.getSteamDiscussion = function(url, callback) {
 
 
 			// Find postedDate and convert to timestamp
-			let posted = $(".topicstats > .topicstats_label:contains(\"Date Posted:\")").next().text();
+			let posted = $('.topicstats > .topicstats_label:contains("Date Posted:")').next().text();
 
 			discussion.postedDate = Helpers.decodeSteamTime(posted.trim());
 
 
 			// Find commentsAmount
-			discussion.commentsAmount = Number($(".topicstats > .topicstats_label:contains(\"Posts:\")").next().text());
+			discussion.commentsAmount = Number($('.topicstats > .topicstats_label:contains("Posts:")').next().text());
 
 
 			// Get discussion title & content
-			discussion.title = $(".forum_op > .topic").text().trim();
-			discussion.content = $(".forum_op > .content").text().trim();
+			discussion.title = $('.forum_op > .topic').text().trim();
+			discussion.content = $('.forum_op > .content').text().trim();
 
 
 			// Find comment marked as answer
-			let hasAnswer = $(".commentthread_answer_bar")
+			let hasAnswer = $('.commentthread_answer_bar');
 
 			if (hasAnswer.length != 0) {
-				let answerPermLink = hasAnswer.next().children(".forum_comment_permlink").text().trim();
+				let answerPermLink = hasAnswer.next().children('.forum_comment_permlink').text().trim();
 
 				// Convert comment id to number, remove hashtag and subtract by 1 to make it an index
-				discussion.answerCommentIndex = Number(answerPermLink.replace("#", "")) - 1;
+				discussion.answerCommentIndex = Number(answerPermLink.replace('#', '')) - 1;
 			}
 
 
 			// Find author and convert to SteamID object
-			let authorLink = $(".authorline > .forum_op_author").attr("href");
+			let authorLink = $('.authorline > .forum_op_author').attr('href');
 
 			Helpers.resolveVanityURL(authorLink, (err, data) => { // This request takes <1 sec
 				if (err) {
@@ -124,8 +124,8 @@ SteamCommunity.prototype.getSteamDiscussion = function(url, callback) {
 		} catch (err) {
 			callback(err, null);
 		}
-	}, "steamcommunity");
-}
+	}, 'steamcommunity');
+};
 
 
 /**

--- a/classes/CSteamDiscussion.js
+++ b/classes/CSteamDiscussion.js
@@ -38,7 +38,7 @@ SteamCommunity.prototype.getSteamDiscussion = function(url, callback) {
 			// Load output into cheerio to make parsing easier
 			let $ = Cheerio.load(body);
 
-			// Get breadcrumbs once
+			// Get breadcrumbs once. Depending on the type of discussion, it either uses "forum" or "group" breadcrumbs
 			let breadcrumbs = $(".forum_breadcrumbs").children();
 
 			if (breadcrumbs.length == 0) breadcrumbs = $(".group_breadcrumbs").children();

--- a/classes/CSteamDiscussion.js
+++ b/classes/CSteamDiscussion.js
@@ -127,3 +127,41 @@ function CSteamDiscussion(community, data) {
 	// Clone all the data we received
 	Object.assign(this, data);
 }
+
+
+/**
+ * Posts a comment to this discussion's comment section
+ * @param {String} message - Content of the comment to post
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+CSteamDiscussion.prototype.postComment = function(message, callback) {
+	this._community.postDiscussionComment(this.topicOwner, this.gidforum, this.id, message, callback);
+};
+
+
+/**
+ * Delete a comment from this discussion's comment section
+ * @param {String} gidcomment - ID of the comment to delete
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+CSteamDiscussion.prototype.deleteComment = function(gidcomment, callback) {
+	this._community.deleteDiscussionComment(this.topicOwner, this.gidforum, this.id, gidcomment, callback);
+};
+
+
+/**
+ * Subscribes to this discussion's comment section
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+CSteamDiscussion.prototype.subscribe = function(callback) {
+	this._community.subscribeDiscussionComments(this.topicOwner, this.gidforum, this.id, callback);
+};
+
+
+/**
+ * Unsubscribes from this discussion's comment section
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+CSteamDiscussion.prototype.unsubscribe = function(callback) {
+	this._community.unsubscribeDiscussionComments(this.topicOwner, this.gidforum, this.id, callback);
+};

--- a/classes/CSteamDiscussion.js
+++ b/classes/CSteamDiscussion.js
@@ -1,7 +1,7 @@
 const Cheerio = require('cheerio');
 const SteamID = require('steamid');
 
-const SteamCommunity  = require('../index.js');
+const SteamCommunity = require('../index.js');
 const Helpers = require('../components/helpers.js');
 
 
@@ -16,6 +16,8 @@ SteamCommunity.prototype.getSteamDiscussion = function(url, callback) {
 		id: null,
 		appID: null,
 		forumID: null,
+		gidforum: null, // This is some id used as parameter 2 in post requests
+		topicOwner: null, // This is some id used as parameter 1 in post requests
 		author: null,
 		postedDate: null,
 		title: null,
@@ -53,6 +55,13 @@ SteamCommunity.prototype.getSteamDiscussion = function(url, callback) {
 			let forumIdHref = breadcrumbs[2].attribs["href"].split("/");
 
 			discussion.forumID = forumIdHref[forumIdHref.length - 2];
+
+
+			// Get gidforum and topicOwner. I'm not 100% sure what they are, they are however used for all post requests
+			let gids = $(".forum_paging > .forum_paging_controls").attr("id").split("_");
+
+			discussion.gidforum = gids[3];
+			discussion.topicOwner = gids[2];
 
 
 			// Find postedDate and convert to timestamp

--- a/classes/CSteamDiscussion.js
+++ b/classes/CSteamDiscussion.js
@@ -41,10 +41,6 @@ SteamCommunity.prototype.getSteamDiscussion = function(url, callback) {
 
 			/* --------------------- Find and map values --------------------- */
 
-			// Get discussionID from url
-			discussion.id = url.split("/")[url.split("/").length - 1];
-
-
 			// Get appID from breadcrumbs
 			let appIdHref = breadcrumbs[0].attribs["href"].split("/");
 
@@ -57,9 +53,10 @@ SteamCommunity.prototype.getSteamDiscussion = function(url, callback) {
 			discussion.forumID = forumIdHref[forumIdHref.length - 2];
 
 
-			// Get gidforum and topicOwner. I'm not 100% sure what they are, they are however used for all post requests
+			// Get id, gidforum and topicOwner. The first is used in the URL itself, the other two only in post requests
 			let gids = $(".forum_paging > .forum_paging_controls").attr("id").split("_");
 
+			discussion.id = gids[4];
 			discussion.gidforum = gids[3];
 			discussion.topicOwner = gids[2];
 

--- a/classes/CSteamDiscussion.js
+++ b/classes/CSteamDiscussion.js
@@ -127,6 +127,17 @@ function CSteamDiscussion(community, data) {
 
 
 /**
+ * Scrapes a range of comments from this discussion
+ * @param {number} startIndex - Index (0 based) of the first comment to fetch
+ * @param {number} endIndex - Index (0 based) of the last comment to fetch
+ * @param {function} callback - First argument is null/Error, second is array containing the requested comments
+ */
+CSteamDiscussion.prototype.getComments = function(startIndex, endIndex, callback) {
+	this._community.getDiscussionComments(`https://steamcommunity.com/app/${this.appID}/discussions/${this.forumID}/${this.id}`, startIndex, endIndex, callback);
+};
+
+
+/**
  * Posts a comment to this discussion's comment section
  * @param {String} message - Content of the comment to post
  * @param {function} callback - Takes only an Error object/null as the first argument

--- a/classes/CSteamDiscussion.js
+++ b/classes/CSteamDiscussion.js
@@ -31,6 +31,11 @@ SteamCommunity.prototype.getSteamDiscussion = function(url, callback) {
 
 	// Get DOM of discussion
 	this.httpRequestGet(url, (err, res, body) => {
+		if (err) {
+			callback(err);
+			return;
+		}
+
 		try {
 
 			/* --------------------- Preprocess output --------------------- */
@@ -43,6 +48,11 @@ SteamCommunity.prototype.getSteamDiscussion = function(url, callback) {
 
 			if (breadcrumbs.length == 0) breadcrumbs = $('.group_breadcrumbs').children();
 
+			// Steam redirects us to the forum page if the discussion does not exist which we can detect by missing breadcrumbs
+			if (!breadcrumbs[0]) {
+				callback(new Error('Discussion not found'));
+				return;
+			}
 
 			/* --------------------- Find and map values --------------------- */
 

--- a/classes/CSteamDiscussion.js
+++ b/classes/CSteamDiscussion.js
@@ -20,7 +20,8 @@ SteamCommunity.prototype.getSteamDiscussion = function(url, callback) {
 		postedDate: null,
 		title: null,
 		content: null,
-		commentsAmount: null // I originally wanted to fetch all comments by default but that would have been a lot of potentially unused data
+		commentsAmount: null, // I originally wanted to fetch all comments by default but that would have been a lot of potentially unused data
+		answerCommentIndex: null
 	};
 
 	// Get DOM of discussion
@@ -67,6 +68,17 @@ SteamCommunity.prototype.getSteamDiscussion = function(url, callback) {
 			// Get discussion title & content
 			discussion.title = $(".forum_op > .topic").text().trim();
 			discussion.content = $(".forum_op > .content").text().trim();
+
+
+			// Find comment marked as answer
+			let hasAnswer = $(".commentthread_answer_bar")
+
+			if (hasAnswer.length != 0) {
+				let answerPermLink = hasAnswer.next().children(".forum_comment_permlink").text().trim();
+
+				// Convert comment id to number, remove hashtag and subtract by 1 to make it an index
+				discussion.answerCommentIndex = Number(answerPermLink.replace("#", "")) - 1;
+			}
 
 
 			// Find author and convert to SteamID object

--- a/classes/CSteamDiscussion.js
+++ b/classes/CSteamDiscussion.js
@@ -171,7 +171,7 @@ CSteamDiscussion.prototype.getComments = function(startIndex, endIndex, callback
  * @param {String} message - Content of the comment to post
  * @param {function} callback - Takes only an Error object/null as the first argument
  */
-CSteamDiscussion.prototype.postComment = function(message, callback) {
+CSteamDiscussion.prototype.comment = function(message, callback) {
 	this._community.postDiscussionComment(this.topicOwner, this.gidforum, this.id, message, callback);
 };
 

--- a/classes/CSteamDiscussion.js
+++ b/classes/CSteamDiscussion.js
@@ -1,0 +1,108 @@
+const Cheerio = require('cheerio');
+const SteamID = require('steamid');
+
+const SteamCommunity  = require('../index.js');
+const Helpers = require('../components/helpers.js');
+
+
+/**
+ * Scrape a discussion's DOM to get all available information
+ * @param {string} url - SteamCommunity url pointing to the discussion to fetch
+ * @param {function} callback - First argument is null/Error, second is object containing all available information
+ */
+SteamCommunity.prototype.getSteamDiscussion = function(url, callback) {
+	// Construct object holding all the data we can scrape
+	let discussion = {
+		id: null,
+		appID: null,
+		forumID: null,
+		author: null,
+		postedDate: null,
+		title: null,
+		content: null,
+		commentsAmount: null // I originally wanted to fetch all comments by default but that would have been a lot of potentially unused data
+	};
+
+	// Get DOM of discussion
+	this.httpRequestGet(url, (err, res, body) => {
+		try {
+
+			/* --------------------- Preprocess output --------------------- */
+
+			// Load output into cheerio to make parsing easier
+			let $ = Cheerio.load(body);
+
+			// Get breadcrumbs once
+			let breadcrumbs = $(".forum_breadcrumbs").children();
+
+
+			/* --------------------- Find and map values --------------------- */
+
+			// Get discussionID from url
+			discussion.id = url.split("/")[url.split("/").length - 1];
+
+
+			// Get appID from breadcrumbs
+			let appIdHref = breadcrumbs[0].attribs["href"].split("/");
+
+			discussion.appID = appIdHref[appIdHref.length - 1];
+
+
+			// Get forumID from breadcrumbs
+			let forumIdHref = breadcrumbs[2].attribs["href"].split("/");
+
+			discussion.forumID = forumIdHref[forumIdHref.length - 2];
+
+
+			// Find postedDate and convert to timestamp
+			let posted = $(".topicstats > .topicstats_label:contains(\"Date Posted:\")").next().text()
+
+			discussion.postedDate = Helpers.decodeSteamTime(posted.trim());
+
+
+			// Find commentsAmount
+			discussion.commentsAmount = Number($(".topicstats > .topicstats_label:contains(\"Posts:\")").next().text());
+
+
+			// Get discussion title & content
+			discussion.title = $(".forum_op > .topic").text().trim();
+			discussion.content = $(".forum_op > .content").text().trim();
+
+
+			// Find author and convert to SteamID object
+			let authorLink = $(".authorline > .forum_op_author").attr("href");
+
+			Helpers.resolveVanityURL(authorLink, (err, data) => { // This request takes <1 sec
+				if (err) {
+					callback(err);
+					return;
+				}
+
+				discussion.author = new SteamID(data.steamID);
+
+				// Make callback when ID was resolved as otherwise owner will always be null
+				callback(null, new CSteamDiscussion(this, discussion));
+			});
+
+		} catch (err) {
+			callback(err, null);
+		}
+	}, "steamcommunity");
+}
+
+
+/**
+ * Constructor - Creates a new Discussion object
+ * @class
+ * @param {SteamCommunity} community
+ * @param {{ id: string, appID: string, forumID: string, author: SteamID, postedDate: Object, title: string, content: string, commentsAmount: number }} data
+ */
+function CSteamDiscussion(community, data) {
+	/**
+	 * @type {SteamCommunity}
+	 */
+	this._community = community;
+
+	// Clone all the data we received
+	Object.assign(this, data);
+}

--- a/classes/CSteamDiscussion.js
+++ b/classes/CSteamDiscussion.js
@@ -63,6 +63,7 @@ SteamCommunity.prototype.getSteamDiscussion = function(url, callback) {
 			if (url.includes('steamcommunity.com/discussions/forum'))     discussion.type = EDiscussionType.Forum;
 			if (/steamcommunity.com\/app\/.+\/discussions/g.test(url))    discussion.type = EDiscussionType.App;
 			if (/steamcommunity.com\/groups\/.+\/discussions/g.test(url)) discussion.type = EDiscussionType.Group;
+			if (/steamcommunity.com\/app\/.+\/eventcomments/g.test(url))  discussion.type = EDiscussionType.Eventcomments;
 
 
 			// Get appID from breadcrumbs if this discussion is associated to one
@@ -73,16 +74,18 @@ SteamCommunity.prototype.getSteamDiscussion = function(url, callback) {
 			}
 
 
-			// Get forumID from breadcrumbs
-			let forumIdHref;
+			// Get forumID from breadcrumbs - Ignore for type Eventcomments as it doesn't have multiple forums
+			if (discussion.type != EDiscussionType.Eventcomments) {
+				let forumIdHref;
 
-			if (discussion.type == EDiscussionType.Group) { // Groups have an extra breadcrumb so we need to shift by 2
-				forumIdHref = breadcrumbs[4].attribs.href.split('/');
-			} else {
-				forumIdHref = breadcrumbs[2].attribs.href.split('/');
+				if (discussion.type == EDiscussionType.Group) { // Groups have an extra breadcrumb so we need to shift by 2
+					forumIdHref = breadcrumbs[4].attribs.href.split('/');
+				} else {
+					forumIdHref = breadcrumbs[2].attribs.href.split('/');
+				}
+
+				discussion.forumID = forumIdHref[forumIdHref.length - 2];
 			}
-
-			discussion.forumID = forumIdHref[forumIdHref.length - 2];
 
 
 			// Get id, gidforum and topicOwner. The first is used in the URL itself, the other two only in post requests
@@ -119,20 +122,24 @@ SteamCommunity.prototype.getSteamDiscussion = function(url, callback) {
 			}
 
 
-			// Find author and convert to SteamID object
-			let authorLink = $('.authorline > .forum_op_author').attr('href');
+			// Find author and convert to SteamID object - Ignore for type Eventcomments as they are posted by the "game", not by an Individual
+			if (discussion.type != EDiscussionType.Eventcomments) {
+				let authorLink = $('.authorline > .forum_op_author').attr('href');
 
-			Helpers.resolveVanityURL(authorLink, (err, data) => { // This request takes <1 sec
-				if (err) {
-					reject(err);
-					return;
-				}
+				Helpers.resolveVanityURL(authorLink, (err, data) => { // This request takes <1 sec
+					if (err) {
+						reject(err);
+						return;
+					}
 
-				discussion.author = new SteamID(data.steamID);
+					discussion.author = new SteamID(data.steamID);
 
-				// Resolve when ID was resolved as otherwise owner will always be null
+					// Resolve when ID was resolved as otherwise owner will always be null
+					resolve(new CSteamDiscussion(this, discussion));
+				});
+			} else {
 				resolve(new CSteamDiscussion(this, discussion));
-			});
+			}
 
 		} catch (err) {
 			reject(err);
@@ -145,7 +152,7 @@ SteamCommunity.prototype.getSteamDiscussion = function(url, callback) {
  * Constructor - Creates a new Discussion object
  * @class
  * @param {SteamCommunity} community
- * @param {{ id: string, appID: string, forumID: string, author: SteamID, postedDate: Object, title: string, content: string, commentsAmount: number }} data
+ * @param {{ id: string, type: EDiscussionType, appID: string, forumID: string, gidforum: string, topicOwner: string, author: SteamID, postedDate: Object, title: string, content: string, commentsAmount: number, answerCommentIndex: number }} data
  */
 function CSteamDiscussion(community, data) {
 	/**

--- a/classes/CSteamDiscussion.js
+++ b/classes/CSteamDiscussion.js
@@ -27,14 +27,15 @@ SteamCommunity.prototype.getSteamDiscussion = function(url, callback) {
 		title: null,
 		content: null,
 		commentsAmount: null, // I originally wanted to fetch all comments by default but that would have been a lot of potentially unused data
-		answerCommentIndex: null
+		answerCommentIndex: null,
+		accountCanComment: null // Is this account allowed to comment on this discussion?
 	};
 
 	// Get DOM of discussion
 	return StdLib.Promises.callbackPromise(null, callback, true, async (resolve, reject) => {
 		let result = await this.httpRequest({
 			method: 'GET',
-			url: url,
+			url: url + '?l=en',
 			source: 'steamcommunity'
 		});
 
@@ -122,6 +123,12 @@ SteamCommunity.prototype.getSteamDiscussion = function(url, callback) {
 			}
 
 
+			// Check if this account is allowed to comment on this discussion
+			let cannotReplyReason = $('.topic_cannotreply_reason');
+
+			discussion.accountCanComment = cannotReplyReason.length == 0;
+
+
 			// Find author and convert to SteamID object - Ignore for type Eventcomments as they are posted by the "game", not by an Individual
 			if (discussion.type != EDiscussionType.Eventcomments) {
 				let authorLink = $('.authorline > .forum_op_author').attr('href');
@@ -152,7 +159,7 @@ SteamCommunity.prototype.getSteamDiscussion = function(url, callback) {
  * Constructor - Creates a new Discussion object
  * @class
  * @param {SteamCommunity} community
- * @param {{ id: string, type: EDiscussionType, appID: string, forumID: string, gidforum: string, topicOwner: string, author: SteamID, postedDate: Object, title: string, content: string, commentsAmount: number, answerCommentIndex: number }} data
+ * @param {{ id: string, type: EDiscussionType, appID: string, forumID: string, gidforum: string, topicOwner: string, author: SteamID, postedDate: Object, title: string, content: string, commentsAmount: number, answerCommentIndex: number, accountCanComment: boolean }} data
  */
 function CSteamDiscussion(community, data) {
 	/**

--- a/classes/CSteamDiscussion.js
+++ b/classes/CSteamDiscussion.js
@@ -131,7 +131,7 @@ SteamCommunity.prototype.getSteamDiscussion = function(url, callback) {
 
 			// Find author and convert to SteamID object - Ignore for type Eventcomments as they are posted by the "game", not by an Individual
 			if (discussion.type != EDiscussionType.Eventcomments) {
-				let authorLink = $('.authorline > .forum_op_author').attr('href');
+				let authorLink = $('.forum_op_author').attr('href');
 
 				Helpers.resolveVanityURL(authorLink, (err, data) => { // This request takes <1 sec
 					if (err) {

--- a/components/discussions.js
+++ b/components/discussions.js
@@ -151,14 +151,25 @@ SteamCommunity.prototype.postDiscussionComment = function(topicOwner, gidforum, 
 			"count": 15,
 			"sessionid": this.getSessionID(),
 			"extended_data": '{"topic_permissions":{"can_view":1,"can_post":1,"can_reply":1}}',
-			"feature2": discussionId
-		}
+			"feature2": discussionId,
+			"json": 1
+		},
+		"json": true
 	}, function(err, response, body) {
 		if (!callback) {
 			return;
 		}
 
-		callback(err);
+		if (err) {
+			callback(err);
+			return;
+		}
+
+		if (body.success) {
+			callback(null);
+		} else {
+			callback(new Error(body.error));
+		}
 	}, "steamcommunity");
 };
 
@@ -178,14 +189,25 @@ SteamCommunity.prototype.deleteDiscussionComment = function(topicOwner, gidforum
 			"count": 15,
 			"sessionid": this.getSessionID(),
 			"extended_data": '{"topic_permissions":{"can_view":1,"can_post":1,"can_reply":1}}',
-			"feature2": discussionId
-		}
-	}, function(err, response, body) {
+			"feature2": discussionId,
+			"json": 1
+		},
+		"json": true
+	}, function(err, response, body) { // Steam does not seem to return any errors here even when trying to delete a non-existing comment but let's check the response anyway
 		if (!callback) {
 			return;
 		}
 
-		callback(err);
+		if (err) {
+			callback(err);
+			return;
+		}
+
+		if (body.success) {
+			callback(null);
+		} else {
+			callback(new Error(body.error));
+		}
 	}, "steamcommunity");
 };
 
@@ -203,14 +225,28 @@ SteamCommunity.prototype.subscribeDiscussionComments = function(topicOwner, gidf
 			"count": 15,
 			"sessionid": this.getSessionID(),
 			"extended_data": '{"topic_permissions":{"can_view":1,"can_post":1,"can_reply":1}}',
-			"feature2": discussionId
-		}
-	}, function(err, response, body) { // eslint-disable-line
+			"feature2": discussionId,
+			"json": 1
+		},
+		"json": true
+	}, function(err, response, body) {
 		if (!callback) {
 			return;
 		}
 
-		callback(err);
+		if (err) {
+			callback(err);
+			return;
+		}
+
+		if (body.success && body.success != SteamCommunity.EResult.OK) {
+			let err = new Error(body.message || SteamCommunity.EResult[body.success]);
+			err.eresult = err.code = body.success;
+			callback(err);
+			return;
+		}
+
+		callback(null);
 	}, "steamcommunity");
 };
 
@@ -228,14 +264,28 @@ SteamCommunity.prototype.unsubscribeDiscussionComments = function(topicOwner, gi
 			"count": 15,
 			"sessionid": this.getSessionID(),
 			"extended_data": '{}', // Unsubscribing does not require any data here
-			"feature2": discussionId
-		}
-	}, function(err, response, body) { // eslint-disable-line
+			"feature2": discussionId,
+			"json": 1
+		},
+		"json": true
+	}, function(err, response, body) {
 		if (!callback) {
 			return;
 		}
 
-		callback(err);
+		if (err) {
+			callback(err);
+			return;
+		}
+
+		if (body.success && body.success != SteamCommunity.EResult.OK) {
+			let err = new Error(body.message || SteamCommunity.EResult[body.success]);
+			err.eresult = err.code = body.success;
+			callback(err);
+			return;
+		}
+
+		callback(null);
 	}, "steamcommunity");
 };
 
@@ -253,12 +303,25 @@ SteamCommunity.prototype.setDiscussionCommentsPerPage = function(value, callback
 			"preference": "topicrepliesperpage",
 			"value": value,
 			"sessionid": this.getSessionID(),
-		}
-	}, function(err, response, body) { // eslint-disable-line
+		},
+		"json": true
+	}, function(err, response, body) { // Steam does not seem to return any errors for this request
 		if (!callback) {
 			return;
 		}
 
-		callback(err);
+		if (err) {
+			callback(err);
+			return;
+		}
+
+		if (body.success && body.success != SteamCommunity.EResult.OK) {
+			let err = new Error(body.message || SteamCommunity.EResult[body.success]);
+			err.eresult = err.code = body.success;
+			callback(err);
+			return;
+		}
+
+		callback(null);
 	}, "steamcommunity");
 };

--- a/components/discussions.js
+++ b/components/discussions.js
@@ -84,17 +84,33 @@ SteamCommunity.prototype.getDiscussionComments = function(url, startIndex, endIn
 			let commentContainer = thisComment.children(".commentthread_comment_content").children(`#comment_content_${thisCommentID}`);
 
 
-			// Prepare comment text by formatting the blockquote if one exists first, then adding the actual content
+			// Prepare comment text by finding all existing blockquotes, formatting them and adding them infront each other. Afterwards handle the text itself
 			let commentText = "";
+			let blockQuoteSelector = ".bb_blockquote";
+			let children = commentContainer.children(blockQuoteSelector);
 
-			if (commentContainer.children(".bb_blockquote").length != 0) { // Check if comment contains quote
-				commentText += commentContainer.children(".bb_blockquote").children(".bb_quoteauthor").text() + "\n"; // Get quote header and add a proper newline
+			for (let i = 0; i < 10; i++) { // I'm not sure how I could dynamically check the amount of nested blockquotes. 10 is prob already too much to stay readable
+				if (children.length > 0) {
+					let thisQuoteText = "";
 
-				let quoteWithNewlines = commentContainer.children(".bb_blockquote").first().find("br").replaceWith("\n"); // Replace <br>'s with newlines to get a proper output
+					thisQuoteText += children.children(".bb_quoteauthor").text() + "\n"; // Get quote header and add a proper newline
 
-				commentText += quoteWithNewlines.end().contents().filter(function() { return this.type === 'text' }).text().trim(); // Get blockquote content without child content - https://stackoverflow.com/a/23956052
+					// Replace <br>'s with newlines to get a proper output
+					let quoteWithNewlines = children.first().find("br").replaceWith("\n");
 
-				commentText += "\n\n-------\n\n"; // Add spacer
+					thisQuoteText += quoteWithNewlines.end().contents().filter(function() { return this.type === 'text' }).text().trim(); // Get blockquote content without child content - https://stackoverflow.com/a/23956052
+					if (i > 0) thisQuoteText += "\n-------\n"; // Add spacer
+
+					commentText = thisQuoteText + commentText; // Concat quoteText to the start of commentText as the most nested quote is the first one inside the comment chain itself
+
+					// Go one level deeper
+					children = children.children(blockQuoteSelector);
+
+				} else {
+
+					commentText += "\n\n-------\n\n"; // Add spacer
+					break;
+				}
 			}
 
 			let quoteWithNewlines = commentContainer.first().find("br").replaceWith("\n"); // Replace <br>'s with newlines to get a proper output

--- a/components/discussions.js
+++ b/components/discussions.js
@@ -133,7 +133,7 @@ SteamCommunity.prototype.postDiscussionComment = function(topicOwner, gidforum, 
 			"comment": message,
 			"count": 15,
 			"sessionid": this.getSessionID(),
-			"extended_data": '{"topic_permissions":{"can_view":1,"can_post":1,"can_reply":1,"is_banned":0,"can_delete":0,"can_edit":0}}', // This parameter is required, not sure about the specific settings
+			"extended_data": '{"topic_permissions":{"can_view":1,"can_post":1,"can_reply":1}}',
 			"feature2": discussionId
 		}
 	}, function(err, response, body) {
@@ -160,7 +160,7 @@ SteamCommunity.prototype.deleteDiscussionComment = function(topicOwner, gidforum
 			"gidcomment": gidcomment,
 			"count": 15,
 			"sessionid": this.getSessionID(),
-			"extended_data": '{"topic_permissions":{"can_view":1,"can_post":1,"can_reply":1,"is_banned":0,"can_delete":0,"can_edit":0}}', // This parameter is required, not sure about the specific settings
+			"extended_data": '{"topic_permissions":{"can_view":1,"can_post":1,"can_reply":1}}',
 			"feature2": discussionId
 		}
 	}, function(err, response, body) {
@@ -185,7 +185,7 @@ SteamCommunity.prototype.subscribeDiscussionComments = function(topicOwner, gidf
 		"form": {
 			"count": 15,
 			"sessionid": this.getSessionID(),
-			"extended_data": '{"topic_permissions":{"can_view":1,"can_post":1,"can_reply":1,"is_banned":0,"can_delete":0,"can_edit":0}}', // This parameter is required, not sure about the specific settings
+			"extended_data": '{"topic_permissions":{"can_view":1,"can_post":1,"can_reply":1}}',
 			"feature2": discussionId
 		}
 	}, function(err, response, body) { // eslint-disable-line

--- a/components/discussions.js
+++ b/components/discussions.js
@@ -1,0 +1,119 @@
+const Cheerio = require('cheerio');
+
+const SteamCommunity = require('../index.js');
+const Helpers = require('../components/helpers.js');
+
+
+/**
+ * Scrapes a range of comments from a Steam discussion
+ * @param {url} url - SteamCommunity url pointing to the discussion to fetch
+ * @param {number} startIndex - Index (0 based) of the first comment to fetch
+ * @param {number} endIndex - Index (0 based) of the last comment to fetch
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+SteamCommunity.prototype.getDiscussionComments = function(url, startIndex, endIndex, callback) {
+	this.httpRequestGet(url + "?l=en", async (err, res, body) => {
+
+		if (err) {
+			callback("Failed to load discussion: " + err, null);
+			return;
+		}
+
+
+		// Load output into cheerio to make parsing easier
+		let $ = Cheerio.load(body);
+
+		let paging = $(".forum_paging > .forum_paging_summary").children();
+
+		/**
+		 * Stores every loaded page inside a Cheerio instance
+		 * @type {{[key: number]: cheerio.Root}}
+		 */
+		let pages = { 
+			0: $
+		};
+
+
+		// Determine amount of comments per page and total. Update endIndex if null to get all comments
+		let commentsPerPage = Number(paging[4].children[0].data);
+		let totalComments   = Number(paging[5].children[0].data)
+
+		if (endIndex == null || endIndex > totalComments - 1) { // Make sure to check against null as the index 0 would cast to false
+			endIndex = totalComments - 1;
+		}
+
+
+		// Save all pages that need to be fetched in order to get the requested comments
+		let firstPage = Math.trunc(startIndex / commentsPerPage); // Index of the first page that needs to be fetched
+		let lastPage  = Math.trunc(endIndex   / commentsPerPage);
+		let promises  = [];
+
+		for (let i = firstPage; i <= lastPage; i++) {
+			if (i == 0) continue; // First page is already in pages object
+
+			promises.push(new Promise((resolve) => {
+				setTimeout(() => { // Delay fetching a bit to reduce the risk of Steam blocking us
+
+					this.httpRequestGet(url + "?l=en&ctp=" + (i + 1), (err, res, body) => {
+						try {
+							pages[i] = Cheerio.load(body);
+							resolve();
+						} catch (err) {
+							return callback("Failed to load comments page: " + err, null);
+						}
+					}, "steamcommunity");
+
+				}, 250 * i);
+			}));
+		}
+
+		await Promise.all(promises); // Wait for all pages to be fetched
+
+
+		// Fill comments with content of all comments
+		let comments = [];
+
+		for (let i = startIndex; i <= endIndex; i++) {
+			let $ = pages[Math.trunc(i / commentsPerPage)];
+
+			let thisComment = $(`.forum_comment_permlink:contains("#${i + 1}")`).parent();
+
+			// Note: '>' inside the cheerio selectors didn't work here
+			let authorContainer = thisComment.children(".commentthread_comment_content").children(".commentthread_comment_author").children(".commentthread_author_link");
+			let commentContainer = thisComment.children(".commentthread_comment_content").children(".commentthread_comment_text");
+
+
+			// Prepare comment text
+			let commentText = "";
+
+			if (commentContainer.children(".bb_blockquote").length != 0) { // Check if comment contains quote
+				commentText += commentContainer.children(".bb_blockquote").children(".bb_quoteauthor").text() + "\n"; // Get quote header and add a proper newline
+
+				let quoteWithNewlines = commentContainer.children(".bb_blockquote").first().find("br").replaceWith("\n"); // Replace <br>'s with newlines to get a proper output
+
+				commentText += quoteWithNewlines.end().contents().filter(function() { return this.type === 'text' }).text().trim(); // Get blockquote content without child content - https://stackoverflow.com/a/23956052
+
+				commentText += "\n\n-------\n\n"; // Add spacer
+			}
+
+			let quoteWithNewlines = commentContainer.first().find("br").replaceWith("\n"); // Replace <br>'s with newlines to get a proper output
+
+			commentText += quoteWithNewlines.end().contents().filter(function() { return this.type === 'text' }).text().trim(); // Add comment content without child content - https://stackoverflow.com/a/23956052
+
+
+			comments.push({
+				index: i,
+				commentId: thisComment.attr("id").replace("comment_", ""),
+				commentLink: `${url}#${thisComment.attr("id").replace("comment_", "c")}`,
+				authorLink: authorContainer.attr("href"),                                 // I did not call 'resolveVanityURL()' here and convert to SteamID to reduce the amount of potentially unused Steam pings
+				postedDate: Helpers.decodeSteamTime(authorContainer.children(".commentthread_comment_timestamp").text().trim()),
+				content: commentText.trim()
+			});
+		}
+
+		
+		// Callback our result
+		callback(null, comments);
+
+    }, "steamcommunity");
+};

--- a/components/discussions.js
+++ b/components/discussions.js
@@ -222,3 +222,27 @@ SteamCommunity.prototype.unsubscribeDiscussionComments = function(topicOwner, gi
 		callback(err);
 	}, "steamcommunity");
 };
+
+/**
+ * Sets an amount of comments per page
+ * @param {String} value - 15, 30 or 50
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+SteamCommunity.prototype.setDiscussionCommentsPerPage = function(value, callback) {
+	if (!["15", "30", "50"].includes(value)) value = "50"; // Check for invalid setting
+
+	this.httpRequestPost({
+		"uri": `https://steamcommunity.com/forum/0/0/setpreference`,
+		"form": {
+			"preference": "topicrepliesperpage",
+			"value": value,
+			"sessionid": this.getSessionID(),
+		}
+	}, function(err, response, body) { // eslint-disable-line
+		if (!callback) {
+			return;
+		}
+
+		callback(err);
+	}, "steamcommunity");
+};

--- a/components/discussions.js
+++ b/components/discussions.js
@@ -77,13 +77,14 @@ SteamCommunity.prototype.getDiscussionComments = function(url, startIndex, endIn
 			let $ = pages[Math.trunc(i / commentsPerPage)];
 
 			let thisComment = $(`.forum_comment_permlink:contains("#${i + 1}")`).parent();
+			let thisCommentID = thisComment.attr("id").replace("comment_", "");
 
 			// Note: '>' inside the cheerio selectors didn't work here
-			let authorContainer = thisComment.children(".commentthread_comment_content").children(".commentthread_comment_author").children(".commentthread_author_link");
-			let commentContainer = thisComment.children(".commentthread_comment_content").children(".commentthread_comment_text");
+			let authorContainer  = thisComment.children(".commentthread_comment_content").children(".commentthread_comment_author").children(".commentthread_author_link");
+			let commentContainer = thisComment.children(".commentthread_comment_content").children(`#comment_content_${thisCommentID}`);
 
 
-			// Prepare comment text
+			// Prepare comment text by formatting the blockquote if one exists first, then adding the actual content
 			let commentText = "";
 
 			if (commentContainer.children(".bb_blockquote").length != 0) { // Check if comment contains quote
@@ -103,8 +104,8 @@ SteamCommunity.prototype.getDiscussionComments = function(url, startIndex, endIn
 
 			comments.push({
 				index: i,
-				commentId: thisComment.attr("id").replace("comment_", ""),
-				commentLink: `${url}#${thisComment.attr("id").replace("comment_", "c")}`,
+				commentId: thisCommentID,
+				commentLink: `${url}#c${thisCommentID}`,
 				authorLink: authorContainer.attr("href"),                                 // I did not call 'resolveVanityURL()' here and convert to SteamID to reduce the amount of potentially unused Steam pings
 				postedDate: Helpers.decodeSteamTime(authorContainer.children(".commentthread_comment_timestamp").text().trim()),
 				content: commentText.trim()

--- a/components/discussions.js
+++ b/components/discussions.js
@@ -9,7 +9,7 @@ const Helpers = require('../components/helpers.js');
  * @param {url} url - SteamCommunity url pointing to the discussion to fetch
  * @param {number} startIndex - Index (0 based) of the first comment to fetch
  * @param {number} endIndex - Index (0 based) of the last comment to fetch
- * @param {function} callback - Takes only an Error object/null as the first argument
+ * @param {function} callback - First argument is null/Error, second is array containing the requested comments
  */
 SteamCommunity.prototype.getDiscussionComments = function(url, startIndex, endIndex, callback) {
 	this.httpRequestGet(url + "?l=en", async (err, res, body) => {

--- a/components/discussions.js
+++ b/components/discussions.js
@@ -1,7 +1,7 @@
 const Cheerio = require('cheerio');
 
 const SteamCommunity = require('../index.js');
-const Helpers = require('../components/helpers.js');
+const Helpers = require('./helpers.js');
 
 
 /**
@@ -240,9 +240,7 @@ SteamCommunity.prototype.subscribeDiscussionComments = function(topicOwner, gidf
 		}
 
 		if (body.success && body.success != SteamCommunity.EResult.OK) {
-			let err = new Error(body.message || SteamCommunity.EResult[body.success]);
-			err.eresult = err.code = body.success;
-			callback(err);
+			callback(Helpers.eresultError(body.success));
 			return;
 		}
 
@@ -279,9 +277,7 @@ SteamCommunity.prototype.unsubscribeDiscussionComments = function(topicOwner, gi
 		}
 
 		if (body.success && body.success != SteamCommunity.EResult.OK) {
-			let err = new Error(body.message || SteamCommunity.EResult[body.success]);
-			err.eresult = err.code = body.success;
-			callback(err);
+			callback(Helpers.eresultError(body.success));
 			return;
 		}
 
@@ -316,9 +312,7 @@ SteamCommunity.prototype.setDiscussionCommentsPerPage = function(value, callback
 		}
 
 		if (body.success && body.success != SteamCommunity.EResult.OK) {
-			let err = new Error(body.message || SteamCommunity.EResult[body.success]);
-			err.eresult = err.code = body.success;
-			callback(err);
+			callback(Helpers.eresultError(body.success));
 			return;
 		}
 

--- a/components/discussions.js
+++ b/components/discussions.js
@@ -119,6 +119,60 @@ SteamCommunity.prototype.getDiscussionComments = function(url, startIndex, endIn
 };
 
 /**
+ * Posts a comment to a discussion
+ * @param {String} topicOwner - ID of the topic owner
+ * @param {String} gidforum - GID of the discussion's forum
+ * @param {String} discussionId - ID of the discussion
+ * @param {String} message - Content of the comment to post
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+SteamCommunity.prototype.postDiscussionComment = function(topicOwner, gidforum, discussionId, message, callback) {
+	this.httpRequestPost({
+		"uri": `https://steamcommunity.com/comment/ForumTopic/post/${topicOwner}/${gidforum}/`,
+		"form": {
+			"comment": message,
+			"count": 15,
+			"sessionid": this.getSessionID(),
+			"extended_data": '{"topic_permissions":{"can_view":1,"can_post":1,"can_reply":1,"is_banned":0,"can_delete":0,"can_edit":0}}', // This parameter is required, not sure about the specific settings
+			"feature2": discussionId
+		}
+	}, function(err, response, body) {
+		if (!callback) {
+			return;
+		}
+
+		callback(err);
+	}, "steamcommunity");
+};
+
+/**
+ * Deletes a comment from a discussion
+ * @param {String} topicOwner - ID of the topic owner
+ * @param {String} gidforum - GID of the discussion's forum
+ * @param {String} discussionId - ID of the discussion
+ * @param {String} gidcomment - ID of the comment to delete
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+SteamCommunity.prototype.deleteDiscussionComment = function(topicOwner, gidforum, discussionId, gidcomment, callback) {
+	this.httpRequestPost({
+		"uri": `https://steamcommunity.com/comment/ForumTopic/delete/${topicOwner}/${gidforum}/`,
+		"form": {
+			"gidcomment": gidcomment,
+			"count": 15,
+			"sessionid": this.getSessionID(),
+			"extended_data": '{"topic_permissions":{"can_view":1,"can_post":1,"can_reply":1,"is_banned":0,"can_delete":0,"can_edit":0}}', // This parameter is required, not sure about the specific settings
+			"feature2": discussionId
+		}
+	}, function(err, response, body) {
+		if (!callback) {
+			return;
+		}
+
+		callback(err);
+	}, "steamcommunity");
+};
+
+/**
  * Subscribes to a discussion's comment section
  * @param {String} topicOwner - ID of the topic owner
  * @param {String} gidforum - GID of the discussion's forum
@@ -131,7 +185,7 @@ SteamCommunity.prototype.subscribeDiscussionComments = function(topicOwner, gidf
 		"form": {
 			"count": 15,
 			"sessionid": this.getSessionID(),
-			"extended_data": '{"topic_permissions":{"can_view":1,"can_post":1,"can_reply":1,"is_banned":0,"can_delete":0,"can_edit":0}}',
+			"extended_data": '{"topic_permissions":{"can_view":1,"can_post":1,"can_reply":1,"is_banned":0,"can_delete":0,"can_edit":0}}', // This parameter is required, not sure about the specific settings
 			"feature2": discussionId
 		}
 	}, function(err, response, body) { // eslint-disable-line

--- a/components/discussions.js
+++ b/components/discussions.js
@@ -117,3 +117,53 @@ SteamCommunity.prototype.getDiscussionComments = function(url, startIndex, endIn
 
     }, "steamcommunity");
 };
+
+/**
+ * Subscribes to a discussion's comment section
+ * @param {String} topicOwner - ID of the topic owner
+ * @param {String} gidforum - GID of the discussion's forum
+ * @param {String} discussionId - ID of the discussion
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+SteamCommunity.prototype.subscribeDiscussionComments = function(topicOwner, gidforum, discussionId, callback) {
+	this.httpRequestPost({
+		"uri": `https://steamcommunity.com/comment/ForumTopic/subscribe/${topicOwner}/${gidforum}/`,
+		"form": {
+			"count": 15,
+			"sessionid": this.getSessionID(),
+			"extended_data": '{"topic_permissions":{"can_view":1,"can_post":1,"can_reply":1,"is_banned":0,"can_delete":0,"can_edit":0}}',
+			"feature2": discussionId
+		}
+	}, function(err, response, body) { // eslint-disable-line
+		if (!callback) {
+			return;
+		}
+
+		callback(err);
+	}, "steamcommunity");
+};
+
+/**
+ * Unsubscribes from a discussion's comment section
+ * @param {String} topicOwner - ID of the topic owner
+ * @param {String} gidforum - GID of the discussion's forum
+ * @param {String} discussionId - ID of the discussion
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+SteamCommunity.prototype.unsubscribeDiscussionComments = function(topicOwner, gidforum, discussionId, callback) {
+	this.httpRequestPost({
+		"uri": `https://steamcommunity.com/comment/ForumTopic/unsubscribe/${topicOwner}/${gidforum}/`,
+		"form": {
+			"count": 15,
+			"sessionid": this.getSessionID(),
+			"extended_data": '{}', // Unsubscribing does not require any data here
+			"feature2": discussionId
+		}
+	}, function(err, response, body) { // eslint-disable-line
+		if (!callback) {
+			return;
+		}
+
+		callback(err);
+	}, "steamcommunity");
+};

--- a/index.js
+++ b/index.js
@@ -587,6 +587,7 @@ require('./components/inventoryhistory.js');
 require('./components/webapi.js');
 require('./components/twofactor.js');
 require('./components/confirmations.js');
+require('./components/discussions.js');
 require('./components/help.js');
 require('./classes/CMarketItem.js');
 require('./classes/CMarketSearchResult.js');

--- a/index.js
+++ b/index.js
@@ -590,6 +590,7 @@ require('./components/confirmations.js');
 require('./components/help.js');
 require('./classes/CMarketItem.js');
 require('./classes/CMarketSearchResult.js');
+require('./classes/CSteamDiscussion.js');
 require('./classes/CSteamGroup.js');
 require('./classes/CSteamSharedFile.js');
 require('./classes/CSteamUser.js');

--- a/resources/EDiscussionType.js
+++ b/resources/EDiscussionType.js
@@ -1,0 +1,13 @@
+/**
+ * @enum EDiscussionType
+ */
+module.exports = {
+	"Forum": 0,
+	"App": 1,
+	"Group": 2,
+
+	// Value-to-name mapping for convenience
+	"0": "Forum",
+	"1": "App",
+	"2": "Group"
+};

--- a/resources/EDiscussionType.js
+++ b/resources/EDiscussionType.js
@@ -5,9 +5,11 @@ module.exports = {
 	Forum: 0,
 	App: 1,
 	Group: 2,
+	Eventcomments: 3,
 
 	// Value-to-name mapping for convenience
 	0: 'Forum',
 	1: 'App',
-	2: 'Group'
+	2: 'Group',
+	3: 'Eventcomments'
 };

--- a/resources/EDiscussionType.js
+++ b/resources/EDiscussionType.js
@@ -2,12 +2,12 @@
  * @enum EDiscussionType
  */
 module.exports = {
-	"Forum": 0,
-	"App": 1,
-	"Group": 2,
+	Forum: 0,
+	App: 1,
+	Group: 2,
 
 	// Value-to-name mapping for convenience
-	"0": "Forum",
-	"1": "App",
-	"2": "Group"
+	0: 'Forum',
+	1: 'App',
+	2: 'Group'
 };


### PR DESCRIPTION
Hey!  
This PR adds support for scraping information and comments from discussions, as well as posting & deleting comments, subscribing & unsubscribing to/from discussions and setting the amount of comments shown per page.  

I have added a new class which represents an existing discussion supplied via URL and scrapes various information from the DOM:  
- `id` (string) - ID of the discussion, is used in the URL
- `type` (EDiscussionType) - Where the discussion is associated to (app, group or the Steam forum)
- `appID` (string) - The appID this discussion is associated to, if of type EDiscussionType.App
- `forumID` (string) - ID of the forum the discussion is in, is used in the URL
- `gidforum` (string) - ID used in post requests when interacting with discussions, not sure why
- `topicOwner` (string) - ID used in post requests when interacting with discussions, not sure why
- `author` (SteamID) - SteamID object of the author of this discussion
- `postedDate` (Date) - When this discussion was created
- `title` (string) - Title of the discussion
- `content` (string) - Content of the discussion
- `commentsAmount` (number) - Amount of comments present in this discussion
- `answerCommentIndex` (number) - If this discussion has an answer, this is the index of the comment

The functions already mentioned above are implemented in `components/discussions.js`.  
Beside the usual functions for commenting and subscribing, it includes another scraper for retrieving a range of comments. Each comment includes the following information:
- `index` (number) - Index of this comment in the comment chain of this discussion
- `commentId` (number) - ID of this comment, issued by Steam
- `commentLink` (string) - Link to this specific comment, will highlight it
- `authorLink` (string) - Profile link of the author of this comment. I did not convert this one to a SteamID to reduce the large amount of extra requests needed to resolve each author link when requesting a large-ish range
- `postedDate` (Date) - When this comment was posted
- `content` (string) - Content of all comments quoted in this comment and the comment itself

I have not added support for posting discussions as a class only represents one discussion, not a forum.

Test code to get 3 comments from the provided discussion and see the nested quotes support:
```js
community.getSteamDiscussion("https://steamcommunity.com/app/739630/discussions/0/1750150652078713439/", (err, res) => {
    res.getComments(35, 37, (err, comments) => {
        console.log(comments);
    });
});
```

Note: I have encountered an error with the scraper yesterday at discussion.js line 39 getting children of undefined, which I was sadly unable to reproduce again. I just wanna note that the scraper might not be completely failsafe, this is however the same case with the other scrapers as well. If I find any bugs I'll ofc look into fixing them and open another PR, just like previously.

Thanks for reading and I hope you find this feature useful.  
Feel free to use the text from this PR in any documentation page if you wish.  
Have a nice day :)