### PR TITLE
Add user/workshop/curator follow & unfollow support

### DIFF
--- a/classes/CSteamUser.js
+++ b/classes/CSteamUser.js
@@ -166,6 +166,14 @@ CSteamUser.prototype.inviteToGroup = function(groupID, callback) {
 	this._community.inviteUserToGroup(this.steamID, groupID, callback);
 };
 
+CSteamUser.prototype.follow = function(callback) {
+	this._community.followUser(this.steamID, callback);
+};
+
+CSteamUser.prototype.unfollow = function(callback) {
+	this._community.unfollowUser(this.steamID, callback);
+};
+
 CSteamUser.prototype.getAliases = function(callback) {
 	this._community.getUserAliases(this.steamID, callback);
 };

--- a/components/groups.js
+++ b/components/groups.js
@@ -755,11 +755,14 @@ SteamCommunity.prototype.followCurator = function(clanid, callback) {
 			return;
 		}
 
-		if (body.success) {
-			callback(null);
-		} else {
-			callback(new Error(EResult[body] || ("Error " + body)));
+		if (body.success && body.success.success != SteamCommunity.EResult.OK) {
+			let err = new Error(body.message || SteamCommunity.EResult[body.success.success]);
+			err.eresult = err.code = body.success.success;
+			callback(err);
+			return;
 		}
+
+		callback(null);
 	}, "steamcommunity");
 };
 
@@ -787,10 +790,13 @@ SteamCommunity.prototype.unfollowCurator = function(clanid, callback) {
 			return;
 		}
 
-		if (body.success) {
-			callback(null);
-		} else {
-			callback(new Error(EResult[body] || ("Error " + body)));
+		if (body.success && body.success.success != SteamCommunity.EResult.OK) {
+			let err = new Error(body.message || SteamCommunity.EResult[body.success.success]);
+			err.eresult = err.code = body.success.success;
+			callback(err);
+			return;
 		}
+
+		callback(null);
 	}, "steamcommunity");
 };

--- a/components/groups.js
+++ b/components/groups.js
@@ -756,9 +756,7 @@ SteamCommunity.prototype.followCurator = function(clanid, callback) {
 		}
 
 		if (body.success && body.success.success != SteamCommunity.EResult.OK) {
-			let err = new Error(body.message || SteamCommunity.EResult[body.success.success]);
-			err.eresult = err.code = body.success.success;
-			callback(err);
+			callback(Helpers.eresultError(body.success.success));
 			return;
 		}
 
@@ -791,9 +789,7 @@ SteamCommunity.prototype.unfollowCurator = function(clanid, callback) {
 		}
 
 		if (body.success && body.success.success != SteamCommunity.EResult.OK) {
-			let err = new Error(body.message || SteamCommunity.EResult[body.success.success]);
-			err.eresult = err.code = body.success.success;
-			callback(err);
+			callback(Helpers.eresultError(body.success.success));
 			return;
 		}
 

--- a/components/groups.js
+++ b/components/groups.js
@@ -730,3 +730,67 @@ SteamCommunity.prototype.respondToAllGroupJoinRequests = function(gid, approve, 
 		}
 	}, "steamcommunity");
 };
+
+/**
+ * Follows a curator page
+ * @param {string} clanid - ID of the curator
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+SteamCommunity.prototype.followCurator = function(clanid, callback) {
+	this.httpRequestPost({
+		"uri": "https://store.steampowered.com/curators/ajaxfollow",
+		"form": {
+			"clanid": clanid,
+			"sessionid": this.getSessionID(),
+			"follow": 1
+		},
+		"json": true
+	}, (err, res, body) => {
+		if (!callback) {
+			return;
+		}
+
+		if (err) {
+			callback(err);
+			return;
+		}
+
+		if (body.success) {
+			callback(null);
+		} else {
+			callback(new Error(EResult[body] || ("Error " + body)));
+		}
+	}, "steamcommunity");
+};
+
+/**
+ * Unfollows a curator page
+ * @param {string} clanid - ID of the curator
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+SteamCommunity.prototype.unfollowCurator = function(clanid, callback) {
+	this.httpRequestPost({
+		"uri": "https://store.steampowered.com/curators/ajaxfollow",
+		"form": {
+			"clanid": clanid,
+			"sessionid": this.getSessionID(),
+			"follow": 0
+		},
+		"json": true
+	}, (err, res, body) => {
+		if (!callback) {
+			return;
+		}
+
+		if (err) {
+			callback(err);
+			return;
+		}
+
+		if (body.success) {
+			callback(null);
+		} else {
+			callback(new Error(EResult[body] || ("Error " + body)));
+		}
+	}, "steamcommunity");
+};

--- a/components/users.js
+++ b/components/users.js
@@ -318,9 +318,7 @@ SteamCommunity.prototype.followUser = function(userID, callback) {
 		}
 
 		if (body.success && body.success != SteamCommunity.EResult.OK) {
-			let err = new Error(body.message || SteamCommunity.EResult[body.success]);
-			err.eresult = err.code = body.success;
-			callback(err);
+			callback(Helpers.eresultError(body.success));
 			return;
 		}
 
@@ -350,9 +348,7 @@ SteamCommunity.prototype.unfollowUser = function(userID, callback) {
 		}
 
 		if (body.success && body.success != SteamCommunity.EResult.OK) {
-			let err = new Error(body.message || SteamCommunity.EResult[body.success]);
-			err.eresult = err.code = body.success;
-			callback(err);
+			callback(Helpers.eresultError(body.success));
 			return;
 		}
 

--- a/components/users.js
+++ b/components/users.js
@@ -317,11 +317,14 @@ SteamCommunity.prototype.followUser = function(userID, callback) {
 			return;
 		}
 
-		if (body.success) {
-			callback(null);
-		} else {
-			callback(new Error("Unknown error"));
+		if (body.success && body.success != SteamCommunity.EResult.OK) {
+			let err = new Error(body.message || SteamCommunity.EResult[body.success]);
+			err.eresult = err.code = body.success;
+			callback(err);
+			return;
 		}
+
+		callback(null);
 	}, "steamcommunity");
 };
 
@@ -346,11 +349,14 @@ SteamCommunity.prototype.unfollowUser = function(userID, callback) {
 			return;
 		}
 
-		if (body.success) {
-			callback(null);
-		} else {
-			callback(new Error("Unknown error"));
+		if (body.success && body.success != SteamCommunity.EResult.OK) {
+			let err = new Error(body.message || SteamCommunity.EResult[body.success]);
+			err.eresult = err.code = body.success;
+			callback(err);
+			return;
 		}
+
+		callback(null);
 	}, "steamcommunity");
 };
 

--- a/components/users.js
+++ b/components/users.js
@@ -296,6 +296,64 @@ SteamCommunity.prototype.inviteUserToGroup = function(userID, groupID, callback)
 	}, "steamcommunity");
 };
 
+SteamCommunity.prototype.followUser = function(userID, callback) {
+	if(typeof userID === 'string') {
+		userID = new SteamID(userID);
+	}
+
+	this.httpRequestPost({
+		"uri": `https://steamcommunity.com/profiles/${userID.toString()}/followuser/`,
+		"form": {
+			"sessionid": this.getSessionID(),
+		},
+		"json": true
+	}, function(err, response, body) {
+		if (!callback) {
+			return;
+		}
+
+		if (err) {
+			callback(err);
+			return;
+		}
+
+		if (body.success) {
+			callback(null);
+		} else {
+			callback(new Error("Unknown error"));
+		}
+	}, "steamcommunity");
+};
+
+SteamCommunity.prototype.unfollowUser = function(userID, callback) {
+	if(typeof userID === 'string') {
+		userID = new SteamID(userID);
+	}
+
+	this.httpRequestPost({
+		"uri": `https://steamcommunity.com/profiles/${userID.toString()}/unfollowuser/`,
+		"form": {
+			"sessionid": this.getSessionID(),
+		},
+		"json": true
+	}, function(err, response, body) {
+		if (!callback) {
+			return;
+		}
+
+		if (err) {
+			callback(err);
+			return;
+		}
+
+		if (body.success) {
+			callback(null);
+		} else {
+			callback(new Error("Unknown error"));
+		}
+	}, "steamcommunity");
+};
+
 SteamCommunity.prototype.getUserAliases = function(userID, callback) {
 	if (typeof userID === 'string') {
 		userID = new SteamID(userID);


### PR DESCRIPTION
Hey, it's me again.  
This PR adds support for following and unfollowing a user.  

Following a user from their profile dropdown or from the user's "Workshop Items" page does the same thing, that's why I mentioned both in the title.  

&nbsp;

Documentation for the CSteamUser wiki page:
```
### follow([callback])
- `callback` - Optional.
    - `err` - `null` on success, an `Error` object on failure

**Non-object method name: `followUser`**

**v3.x.x or later is required to use this method.**

Follows the user and their workshop.

### unfollow([callback])
- `callback` - Optional.
    - `err` - `null` on success, an `Error` object on failure

**Non-object method name: `unfollowUser`**

**v3.x.x or later is required to use this method.**

Unfollows the user and their workshop.
```
Don't forget to fill out the version number should you copy and paste this.

&nbsp;

That's it, I hope the amount of PRs by me don't get on your nerves too much (warning: there is probably one more coming soon because I want to add support for reviews).  
Have a nice day :)