### PR TITLE
Update profile component to promises/update jsdoc

### DIFF
--- a/components/http.js
+++ b/components/http.js
@@ -71,6 +71,7 @@ SteamCommunity.prototype.httpRequest = function(options) {
 /**
  * @param {string|object} endpoint
  * @param {object} [form]
+ * @return {Promise<HttpResponse>}
  * @private
  */
 SteamCommunity.prototype._myProfile = async function(endpoint, form) {


### PR DESCRIPTION
In the `/components/profile.js` file, all of the prototype functions were refactored to use `callbackPromise`s from Doctor McKay's `StdLib`. In the "for in" loops in the `editProfile` and `profileSettings` functions, the variable "i" was changed to "name" to be a bit more descriptive. The JSDoc for each prototype function was also updated to reflect the changes stated above.