### PR TITLE
fix: getUserInventoryContents() make unnecesary calls

### DIFF
--- a/components/users.js
+++ b/components/users.js
@@ -590,7 +590,7 @@ SteamCommunity.prototype.getUserInventoryContents = function(userID, appID, cont
 			},
 			"qs": {
 				"l": language, // Default language
-				"count": 2000, // Max items per 'page'
+				"count": 5000, // Max items per 'page'
 				"start_assetid": start
 			},
 			"json": true


### PR DESCRIPTION
Steam inventory limits are back to normal there is no reason to just gather 2k items instead 5k max allowed by API