### PR TITLE
feat: Extend existing sharedfiles implementation

### DIFF
--- a/classes/CSteamSharedFile.js
+++ b/classes/CSteamSharedFile.js
@@ -247,3 +247,19 @@ CSteamSharedFile.prototype.unfavorite = function(callback) {
 CSteamSharedFile.prototype.unsubscribe = function(callback) {
 	this._community.unsubscribeSharedFileComments(this.owner, this.id, callback);
 };
+
+/**
+ * Subscribes to this workshop item
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+CSteamSharedFile.prototype.subscribeWorkshop = function(callback) {
+	this._community.subscribeWorkshopSharedFile(this.id, this.appID, callback);
+};
+
+/**
+ * Unsubscribes from this workshop item
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+CSteamSharedFile.prototype.unsubscribeWorkshop = function(callback) {
+	this._community.unsubscribeWorkshopSharedFile(this.id, this.appID, callback);
+};

--- a/classes/CSteamSharedFile.js
+++ b/classes/CSteamSharedFile.js
@@ -22,6 +22,7 @@ SteamCommunity.prototype.getSteamSharedFile = function(sharedFileId, callback) {
 		fileSize: null,
 		postDate: null,
 		resolution: null,
+		categories: [],
 		uniqueVisitorsCount: null,
 		favoritesCount: null,
 		upvoteCount: null,
@@ -114,6 +115,14 @@ SteamCommunity.prototype.getSteamSharedFile = function(sharedFileId, callback) {
 			}
 
 
+			// Find categories if guide or workshop item
+			if (sharedfile.type == ESharedFileType.Guide || sharedfile.type == ESharedFileType.Workshop) {
+				let categoryTag = $(".workshopTagsTitle:contains(\"Category:\")").parent().contents().slice(1).text(); // Find div containing 'Category:' workshopTagsTitle, remove first element 'Category:' and get everything else as text
+
+				sharedfile.categories = categoryTag ? categoryTag.split(", ") : []; // Convert to array if string is not empty (aka no categories have been found)
+			}
+
+
 			// Find uniqueVisitorsCount. We can't use ' || null' here as Number("0") casts to false
 			if (statsTableObj["Unique Visitors"]) {
 				sharedfile.uniqueVisitorsCount = Number(statsTableObj["Unique Visitors"]);
@@ -170,7 +179,7 @@ SteamCommunity.prototype.getSteamSharedFile = function(sharedFileId, callback) {
  * Constructor - Creates a new SharedFile object
  * @class
  * @param {SteamCommunity} community
- * @param {{ id: string, type: ESharedFileType, appID: number, owner: SteamID|null, fileSize: string|null, postDate: number, resolution: string|null, uniqueVisitorsCount: number, favoritesCount: number, upvoteCount: number|null, guideNumRatings: Number|null, isUpvoted: boolean, isDownvoted: boolean }} data
+ * @param {{ id: string, type: ESharedFileType, appID: number, owner: SteamID|null, fileSize: string|null, postDate: number, resolution: string|null, category: string[], uniqueVisitorsCount: number, favoritesCount: number, upvoteCount: number|null, guideNumRatings: Number|null, isUpvoted: boolean, isDownvoted: boolean }} data
  */
 function CSteamSharedFile(community, data) {
 	/**

--- a/classes/CSteamSharedFile.js
+++ b/classes/CSteamSharedFile.js
@@ -23,6 +23,7 @@ SteamCommunity.prototype.getSteamSharedFile = function(sharedFileId, callback) {
 		postDate: null,
 		resolution: null,
 		categories: [],
+		tags: [],
 		uniqueVisitorsCount: null,
 		favoritesCount: null,
 		upvoteCount: null,
@@ -123,6 +124,12 @@ SteamCommunity.prototype.getSteamSharedFile = function(sharedFileId, callback) {
 			}
 
 
+			// Find tags (there can be multiple)
+			let tagsTag = $(".workshopTagsTitle:contains(\"Tags:\")").next().contents();
+
+			sharedfile.tags = tagsTag.map((i, e) => e.type === 'text' ? $(e).text() : '').get() || []; // Map text to an array - https://stackoverflow.com/a/31543727
+
+
 			// Find uniqueVisitorsCount. We can't use ' || null' here as Number("0") casts to false
 			if (statsTableObj["Unique Visitors"]) {
 				sharedfile.uniqueVisitorsCount = Number(statsTableObj["Unique Visitors"]);
@@ -179,7 +186,7 @@ SteamCommunity.prototype.getSteamSharedFile = function(sharedFileId, callback) {
  * Constructor - Creates a new SharedFile object
  * @class
  * @param {SteamCommunity} community
- * @param {{ id: string, type: ESharedFileType, appID: number, owner: SteamID|null, fileSize: string|null, postDate: number, resolution: string|null, category: string[], uniqueVisitorsCount: number, favoritesCount: number, upvoteCount: number|null, guideNumRatings: Number|null, isUpvoted: boolean, isDownvoted: boolean }} data
+ * @param {{ id: string, type: ESharedFileType, appID: number, owner: SteamID|null, fileSize: string|null, postDate: number, resolution: string|null, category: string[], tags: string[], uniqueVisitorsCount: number, favoritesCount: number, upvoteCount: number|null, guideNumRatings: Number|null, isUpvoted: boolean, isDownvoted: boolean }} data
  */
 function CSteamSharedFile(community, data) {
 	/**

--- a/classes/CSteamSharedFile.js
+++ b/classes/CSteamSharedFile.js
@@ -228,7 +228,7 @@ CSteamSharedFile.prototype.comment = function(message, callback) {
  * Subscribes to this sharedfile's comment section. Note: Checkbox on webpage does not update
  * @param {function} callback - Takes only an Error object/null as the first argument
  */
-CSteamSharedFile.prototype.subscribe = function(callback) {
+CSteamSharedFile.prototype.subscribeComments = function(callback) {
 	this._community.subscribeSharedFileComments(this.owner, this.id, callback);
 };
 
@@ -244,7 +244,7 @@ CSteamSharedFile.prototype.unfavorite = function(callback) {
  * Unsubscribes from this sharedfile's comment section. Note: Checkbox on webpage does not update
  * @param {function} callback - Takes only an Error object/null as the first argument
  */
-CSteamSharedFile.prototype.unsubscribe = function(callback) {
+CSteamSharedFile.prototype.unsubscribeComments = function(callback) {
 	this._community.unsubscribeSharedFileComments(this.owner, this.id, callback);
 };
 

--- a/components/sharedfiles.js
+++ b/components/sharedfiles.js
@@ -132,7 +132,7 @@ SteamCommunity.prototype.unfavoriteSharedFile = function(sharedFileId, appid, ca
 };
 
 /**
- * Unsubscribes from a sharedfile's comment section. Note: Checkbox on webpage does not update
+ * Unsubscribes from a sharedfile's comment section.
  * @param {SteamID | String} userID - ID of the user associated to this sharedfile
  * @param {String} sharedFileId - ID of the sharedfile
  * @param {function} callback - Takes only an Error object/null as the first argument
@@ -149,6 +149,52 @@ SteamCommunity.prototype.unsubscribeSharedFileComments = function(userID, shared
 			"sessionid": this.getSessionID()
 		}
 	}, function(err, response, body) { // eslint-disable-line
+		if (!callback) {
+			return;
+		}
+
+		callback(err);
+	}, "steamcommunity");
+};
+
+/**
+ * Subscribes to a workshop item sharedfile.
+ * @param {String} sharedFileId - ID of the sharedfile
+ * @param {String} appid - ID of the app associated to this sharedfile
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+SteamCommunity.prototype.subscribeWorkshopSharedFile = function(sharedFileId, appid, callback) {
+	this.httpRequestPost({
+		"uri": "https://steamcommunity.com/sharedfiles/subscribe",
+		"form": {
+			"id": sharedFileId,
+			"appid": appid,
+			"sessionid": this.getSessionID()
+		}
+	}, function(err, response, body) {
+		if (!callback) {
+			return;
+		}
+
+		callback(err);
+	}, "steamcommunity");
+};
+
+/**
+ * Unsubscribes from a workshop item sharedfile.
+ * @param {String} sharedFileId - ID of the sharedfile
+ * @param {String} appid - ID of the app associated to this sharedfile
+ * @param {function} callback - Takes only an Error object/null as the first argument
+ */
+SteamCommunity.prototype.unsubscribeWorkshopSharedFile = function(sharedFileId, appid, callback) {
+	this.httpRequestPost({
+		"uri": "https://steamcommunity.com/sharedfiles/unsubscribe",
+		"form": {
+			"id": sharedFileId,
+			"appid": appid,
+			"sessionid": this.getSessionID()
+		}
+	}, function(err, response, body) {
 		if (!callback) {
 			return;
 		}

--- a/resources/ESharedFileType.js
+++ b/resources/ESharedFileType.js
@@ -5,9 +5,11 @@ module.exports = {
 	"Screenshot": 0,
 	"Artwork": 1,
 	"Guide": 2,
+	"Workshop": 3,
 
 	// Value-to-name mapping for convenience
 	"0": "Screenshot",
 	"1": "Artwork",
-	"2": "Guide"
+	"2": "Guide",
+	"3": "Workshop"
 };


### PR DESCRIPTION
Hi,  
this PR extends the existing sharedfiles implementation to...:
- detect workshop item objects as type
- scrape categories
- scrape tags
- implement functions to un-/subscribe from/to workshop items
- rename object methods for un-/subscribing from/to comments to separate them more clearly

Workshop Items are also listed as sharedfiles on the SteamCommunity (see the CS2 [Insertion2](https://steamcommunity.com/sharedfiles/filedetails/?id=3236615060) map for example), which is why I added support to the existing sharedfiles class, instead of adding a new one.

This PR might display conflicts later on as it is based on the master branch and not on the fixes of my two other sharedfiles PRs (`#315` & `#316`). I'll address them gladly when it is time.

Thanks!