### PR TITLE
Empty giftnames can be valid

### DIFF
--- a/components/market.js
+++ b/components/market.js
@@ -291,7 +291,7 @@ SteamCommunity.prototype.getGiftDetails = function(giftID, callback) {
 			return;
 		}
 
-		if (!body.packageid || !body.gift_name) {
+		if (!body.packageid) {
 			callback(new Error("Malformed response"));
 			return;
 		}


### PR DESCRIPTION
I got an incorrect error from this gift unpack response:

```json
{
   "gift_name" : "",
   "message" : "<div class=\"gift_ownershipcheck\">\r\n\t\t\t<h2>This gift is already in your library.</h2>\r\n\t\t<div class=\"buttons\" id=\"unpack_gift_buttons_4061760541041388893\">\r\n\t\t\t<div class=\"btn_grey_white_innerfade btn_medium\" onclick=\"hideModal( 'gift_modal' );\">\r\n\t\t\t\t<span>OK</span>\r\n\t\t\t</div>\r\n\t\t</div>\r\n\t\t<div id=\"unpack_gift_buttons_4061760541041388893_wait\" style=\"display: none;\">\r\n\t\t<p>&nbsp;<img src=\"https://community.akamai.steamstatic.com/public/images/login/throbber.gif\">&nbsp;</p>\r\n\t</div>\r\n</div>",
   "owned" : true,
   "packageid" : "29458",
   "success" : 1
}

```

This should fix it