### PR TITLE
Fixes cache_expiration restore for CS2 Items

### DIFF
--- a/classes/CEconItem.js
+++ b/classes/CEconItem.js
@@ -68,9 +68,9 @@ function CEconItem(item, description, contextID) {
 
 	// Restore cache_expiration, if we can (for CS:GO items)
 	if (this.appid == 730 && this.contextid == 2 && this.owner_descriptions) {
-		let description = this.owner_descriptions.find(d => d.value && d.value.indexOf('Tradable After ') == 0);
+		let description = this.owner_descriptions.find(d => d.value && d.value.indexOf('Tradable/Marketable After ') == 0);
 		if (description) {
-			let date = new Date(description.value.substring(15).replace(/[,()]/g, ''));
+			let date = new Date(description.value.substring(26).replace(/[,()]/g, ''));
 			if (date) {
 				this.cache_expiration = date.toISOString();
 			}


### PR DESCRIPTION
As of Oct 2024, CS2 Item owner_description has changed from "Tradable After" to "Tradable/Marketable After". This fixes cache_expiration, which is currently always going to be null as it's never found in the owner_descriptions array. 