### PR TITLE
Get Trade Partner Inventory

### DIFF
--- a/components/users.js
+++ b/components/users.js
@@ -675,6 +675,104 @@ SteamCommunity.prototype.getUserInventoryContents = function(userID, appID, cont
 	}
 };
 
+
+
+/**
+ * Get the contents of a user's inventory from trade window.
+ * @param {SteamID|string} partner - The user's SteamID as a SteamID object or a string which can parse into one
+ * @param {string} [token] - Their trade token
+ * @param {int} appID - The Steam application ID of the game for which you want an inventory
+ * @param {int} contextID - The ID of the "context" within the game you want to retrieve
+ * @param {function} callback
+ */
+SteamCommunity.prototype.getTradePartnerInventory = function(partner,token, appID, contextID, callback) {
+	if (typeof contextID === 'function') {
+		callback = contextID;
+		contextID = appID;
+		appID = token;
+	}
+
+	if (typeof partner === 'string' && partner.match(/^https?:\/\//)) {
+		// It's a trade URL I guess
+		var url = require('url').parse(partner, true);
+		if (!url.query.partner) {
+			throw new Error("Invalid trade URL");
+		}
+
+		partner = SteamID.fromIndividualAccountID(url.query.partner);
+		token = url.query.token;
+	}
+
+	var self = this;
+
+	if (typeof partner === 'string') {
+		partner = new SteamID(partner);
+	}
+
+	get([], []);
+
+	function get(inventory, currency) {
+		self.httpRequest({
+			"uri": `https://steamcommunity.com/tradeoffer/new/partnerinventory`,
+			"headers": {
+				"Referer": `https://steamcommunity.com/tradeoffer/new/?partner=${partner.accountid}&token=${token}`
+			},
+			"qs": {
+				"sessionid": this.getSessionID(),
+				"partner": partner.getSteamID64(),
+				"appid": appID,
+				"contextid": contextID,
+			},
+			"json": true
+		}, function (err, response, body) {
+			if (err) {
+				callback(err);
+				return;
+			}
+
+			if (!body || !body.success || !body.rgInventory || !body.rgDescriptions || !body.rgCurrency) {
+				if(body && Array.isArray(body) && body.length === 2 && body[0] === 'success' && body[1] === false) {
+					callback(new Error("This profile is private."));
+				} else {
+					callback(new Error("Malformed response"));
+				}
+
+				return;
+			}
+
+			if (!body || !body.success || !body.rgInventory || !body.rgDescriptions || !body.rgCurrency) {
+				if (body) {
+					callback(new Error(body.Error || "Malformed response"));
+				} else {
+					callback(new Error("Malformed response"));
+				}
+
+				return;
+			}
+
+			var i;
+			for (i in body.rgInventory) {
+				if (!body.rgInventory.hasOwnProperty(i)) {
+					continue;
+				}
+
+				inventory.push(new CEconItem(body.rgInventory[i], body.rgDescriptions, contextID));
+			}
+
+			for (i in body.rgCurrency) {
+				if (!body.rgCurrency.hasOwnProperty(i)) {
+					continue;
+				}
+
+				currency.push(new CEconItem(body.rgCurrency[i], body.rgDescriptions, contextID));
+			}
+
+			callback(null, inventory, currency);
+		}, "steamcommunity");
+	}
+};
+
+
 /**
  * Upload an image to Steam and send it to another user over Steam chat.
  * @param {SteamID|string} userID - Either a SteamID object or a string that can parse into one

--- a/components/users.js
+++ b/components/users.js
@@ -740,16 +740,6 @@ SteamCommunity.prototype.getTradePartnerInventory = function(partner,token, appI
 				return;
 			}
 
-			if (!body || !body.success || !body.rgInventory || !body.rgDescriptions || !body.rgCurrency) {
-				if (body) {
-					callback(new Error(body.Error || "Malformed response"));
-				} else {
-					callback(new Error("Malformed response"));
-				}
-
-				return;
-			}
-
 			var i;
 			for (i in body.rgInventory) {
 				if (!body.rgInventory.hasOwnProperty(i)) {

--- a/components/users.js
+++ b/components/users.js
@@ -718,7 +718,7 @@ SteamCommunity.prototype.getTradePartnerInventory = function(partner,token, appI
 				"Referer": `https://steamcommunity.com/tradeoffer/new/?partner=${partner.accountid}&token=${token}`
 			},
 			"qs": {
-				"sessionid": this.getSessionID(),
+				"sessionid": self.getSessionID(),
 				"partner": partner.getSteamID64(),
 				"appid": appID,
 				"contextid": contextID,


### PR DESCRIPTION
Retrieve the user’s inventory using the Trade Offer URL endpoint. This method returns only tradeable items, including those affected by the 10-day visibility restriction introduced in the CS2 update on April 3, 2024. As per the update, purchased and traded Counter-Strike items will remain hidden from other users viewing your Steam Inventory for 10 days.