### PR TITLE
fix: steam now only accepts 1000 <

### DIFF
--- a/components/users.js
+++ b/components/users.js
@@ -590,7 +590,7 @@ SteamCommunity.prototype.getUserInventoryContents = function(userID, appID, cont
 			},
 			"qs": {
 				"l": language, // Default language
-				"count": 5000, // Max items per 'page'
+				"count": 1000, // Max items per 'page'
 				"start_assetid": start
 			},
 			"json": true


### PR DESCRIPTION
After last steam update it only accepts 1000 as `count` when fetching inventory.

This fixes the 400 response error.