### PR TITLE
fix: steam moved to 2k items per inventory request

### DIFF
--- a/components/users.js
+++ b/components/users.js
@@ -590,7 +590,7 @@ SteamCommunity.prototype.getUserInventoryContents = function(userID, appID, cont
 			},
 			"qs": {
 				"l": language, // Default language
-				"count": 1000, // Max items per 'page'
+				"count": 2000, // Max items per 'page'
 				"start_assetid": start
 			},
 			"json": true


### PR DESCRIPTION
@DoctorMcKay backend support up to 2500 items as for today.
Official limit for front-end (network tab) is 2k

Up to you which limit to set.