### PR TITLE
added a method to normalize user status so that it displays non-steam…

### DIFF
--- a/classes/CSteamUser.js
+++ b/classes/CSteamUser.js
@@ -3,6 +3,11 @@ var Helpers = require('../components/helpers.js');
 var SteamID = require('steamid');
 var xml2js = require('xml2js');
 
+function normalizeStateMessage(message) {
+  if (typeof message !== 'string') return message;
+  return message.replace(/<br\s*\/?>(\s*)?/gi, ' ').trim();
+}
+
 SteamCommunity.prototype.getSteamUser = function(id, callback) {
 	if(typeof id !== 'string' && !Helpers.isSteamID(id)) {
 		throw new Error("id parameter should be a user URL string or a SteamID object");
@@ -55,7 +60,7 @@ function CSteamUser(community, userData, customurl) {
 	this.steamID = new SteamID(userData.steamID64[0]);
 	this.name = processItem('steamID');
 	this.onlineState = processItem('onlineState');
-	this.stateMessage = processItem('stateMessage');
+	this.stateMessage = normalizeStateMessage(processItem('stateMessage'));
 	this.privacyState = processItem('privacyState', 'uncreated');
 	this.visibilityState = processItem('visibilityState');
 	this.avatarHash = processItem('avatarIcon', '').match(/([0-9a-f]+)\.[a-z]+$/);


### PR DESCRIPTION
## Problem
Some profiles include `<br/>` inside `stateMessage` (e.g., "In non-Steam game<br/>Factorio"). Consumers then see a truncated or multi-line status string.

## Change
Added a helper `normalizeStateMessage()` and now call it when constructing `CSteamUser`, replacing `<br/>` (case/spacing variants) with a space and trimming.

## Why here
The value comes from profile XML; normalizing at parse time ensures a clean, single-line field for all downstream users.

## Testing
- Verified with a small XML parse snippet that `"In non-Steam game<br/>Factorio"` becomes `"In non-Steam game Factorio"`.
- No other fields modified.

## Related
Fixes #290
