### PR TITLE
Fix CEconItem crash when "Tradable/Marketable After" date isn't day-first

### DIFF
--- a/classes/CEconItem.js
+++ b/classes/CEconItem.js
@@ -70,19 +70,24 @@ function CEconItem(item, description, contextID, assetProperties) {
 	if (this.appid == 730 && this.contextid == 2 && this.owner_descriptions) {
 		let description = this.owner_descriptions.find((d) => d.value && d.value.indexOf("Tradable/Marketable After ") == 0);
 		if (description) {
+			let date;
 			const match = description.value.match(/(\d{1,2}) (\w+) @ (\d{1,2}:\d{2})(am|pm)/i);
-			const [, day, month, time, meridian] = match;
-			const now = new Date();
-			let year = now.getFullYear();
-			let date = new Date(`${day} ${month} ${year} ${time} ${meridian}`);
+			if (match) {
+				// New day-first format, e.g. "Tradable/Marketable After 17 Jul @ 3:00am"
+				const [, day, month, time, meridian] = match;
+				const now = new Date();
+				let year = now.getFullYear();
+				date = new Date(`${day} ${month} ${year} ${time} ${meridian}`);
 
-			if (date.getTime() < now.getTime()) {
-				date = new Date(
-					`${day} ${month} ${year + 1} ${time} ${meridian}`,
-				);
+				if (date.getTime() < now.getTime()) {
+					date = new Date(`${day} ${month} ${year + 1} ${time} ${meridian}`);
+				}
+			} else {
+				// Legacy month-first format, e.g. "Tradable/Marketable After Jul 11, 2025 (2:00:00)"
+				date = new Date(description.value.substring("Tradable/Marketable After ".length).replace(/[,()]/g, ""));
 			}
 
-			if (date) {
+			if (date && !isNaN(date.getTime())) {
 				this.cache_expiration = date.toISOString();
 			}
 		}


### PR DESCRIPTION
### Problem

`CEconItem`'s constructor destructures the result of the day-first "Tradable/Marketable After" date regex **without checking whether it matched**:

```js
const match = description.value.match(/(\d{1,2}) (\w+) @ (\d{1,2}:\d{2})(am|pm)/i);
const [, day, month, time, meridian] = match; // throws if match === null
```

For a CS2 item (`appid 730`, `contextid 2`) whose `owner_descriptions` contain a `Tradable/Marketable After …` string that is **not** in the day-first format — e.g. the older month-first form `Tradable/Marketable After Jul 11, 2025 (2:00:00)` — `match` is `null` and the destructuring throws:

```
TypeError: match is not iterable
```

Because this runs inside the constructor, the error propagates out of `getInventoryContents()` / `getUserInventoryContents()`, so the **entire inventory fetch rejects** instead of returning items — a single such held item takes down the whole call.

Minimal repro:

```js
const CEconItem = require('steamcommunity/classes/CEconItem.js');
new CEconItem({
	appid: 730,
	contextid: 2,
	owner_descriptions: [{value: 'Tradable/Marketable After Jul 11, 2025 (2:00:00)'}]
});
// TypeError: match is not iterable
```

### Fix

Guard the `null` match, fall back to parsing the legacy month-first format (the same parsing used before the day-first regex was introduced), and only set `cache_expiration` when a valid `Date` is produced.

Behavior:

- **day-first** strings (`… After 17 Jul @ 3:00am`) — unchanged.
- **month-first** strings (`… After Jul 11, 2025 (2:00:00)`) — parsed instead of throwing.
- **unparseable** strings — leave `cache_expiration` unset instead of crashing (the previous `if (date)` guard never caught this, since an `Invalid Date` is truthy and `.toISOString()` on it throws `RangeError`).

Backwards-compatible; no version bump (per CONTRIBUTING).
